### PR TITLE
fixSelection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -143,7 +143,7 @@ export default class Ed {
     let doc = GridToDoc(this._content)
     // TODO merge placeholders
     // Cache selection to restore after DOM update
-    let selection = this.pm.selection
+    let selection = fixSelection(this.pm.selection, doc)
     // Populate ProseMirror
     this.pm.setDoc(doc, selection)
   }
@@ -176,4 +176,15 @@ function mergeContent (oldContent, newContent) {
   // TODO make this a little smarter
   // Only add new placeholders and update exiting placeholders
   return newContent
+}
+
+// Can't restore selection to a non-focuable (Media) div
+function fixSelection (selection, doc) {
+  let index = selection.anchor.path[0]
+  console.log(selection, doc.content.content[index].type)
+  while (doc.content.content[index].type.contains === null) {
+    index++
+  }
+  selection.anchor.path[0] = index
+  return selection
 }


### PR DESCRIPTION
When ed.setContent is called, selection is cached and restored. In cases where a placeholder div is spliced to the position where the caret was (as demo upload image) PM would throw.

The fix is naïve, just checks if the selection is in a leaf node and bumps it down if so.

Bigger question remains if we should allow ed.setContent at all, or rely on more-granular content updates.
#50
