### PR TITLE
smarter merge

### DIFF
--- a/src/ed.js
+++ b/src/ed.js
@@ -149,7 +149,7 @@ export default class Ed {
     content.splice(index, 1, block)
     this._content = content
     // Render
-    this.setContent(content)
+    this.setContent(content, false)
   }
   insertBlocks (index, blocks) {
     const content = this.getContent()
@@ -157,12 +157,16 @@ export default class Ed {
     const newContent = arrayInsertAll(content, index, blocks)
     this._content = newContent
     // Render
-    this.setContent(newContent)
+    this.setContent(newContent, false)
     // Signal
     this.onChange()
   }
-  setContent (content) {
-    this._content = mergeContent(this._content, content)
+  setContent (content, needsMerge = true) {
+    if (needsMerge) {
+      this._content = mergeContent(this.getContent(), content)
+    } else {
+      this._content = content
+    }
     let doc = GridToDoc(this._content)
     // Cache selection to restore after DOM update
     let selection = fixSelection(this.pm.selection, doc)


### PR DESCRIPTION
Issue's root was that setContent was merging with `_content`, which can be keystrokes behind the doc state at the time of merge.

(`_content` is really just for caching media block metadata. Might make sense to refactor that as a object with ids as keys, which would make accessing it easier.)
