### PR TITLE
onPlaceholderCancel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
   * `progress` 0-100 with `ed.updatePlaceholder(id, status, progress)` or `ed.setContent([{id, metadata: {status, progress}}])`
 * NEW -- **X** button on the Placeholder component triggers `options.onPlaceholderCancel(id)`
   * When that is hit, `ed.getContent()` will already have removed the cancelled placeholder block
+* Delete from under media block ignored
 
 ## 0.5.0 - The Fold - 2016-03-15
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## dev
 
+* Placeholder progress bar
+  * `progress` 0-100 with `ed.updatePlaceholder(id, status, progress)` or `ed.setContent([{id, metadata: {status, progress}}])`
+* NEW -- **X** button on the Placeholder component triggers `options.onPlaceholderCancel(id)`
+  * When that is hit, `ed.getContent()` will already have removed the cancelled placeholder block
+
 ## 0.5.0 - The Fold - 2016-03-15
 
 * **The Fold** view above main editable for sharing and editing one primary media block

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ ProseMirror provides a high-level schema-based interface for interacting with `c
       /* Ed made the placeholder with block id */
       /* App shares url with given block id */
       /* On share / measurement finishing, app replaces placeholder blocks with ed.setContent */
+    },
+    onPlaceholderCancel: function (id) {
+      /* Ed removed the placeholder if you call ed.getContent() now */
+      /* App should cancel the share or upload */
     }
   })  
 ```

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -233,4 +233,4 @@ document.querySelector('#fixture').onclick = loadFixture
 
 function onPlaceholderCancelDemo (id) {
   console.log(`App would cancel the share or upload with id: ${id}`)
-} 
+}

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -27,6 +27,7 @@ function setup (options) {
     , autosaveInterval: 1000
     , onShareFile: onShareFileDemo
     , onShareUrl: onShareUrlDemo
+    , onPlaceholderCancel: onPlaceholderCancelDemo
     , imgfloConfig: null
     }
   )
@@ -229,3 +230,7 @@ function loadFixture () {
 }
 document.querySelector('#fixture').onclick = loadFixture
 
+
+function onPlaceholderCancelDemo (id) {
+  console.log(`App would cancel the share or upload with id: ${id}`)
+} 

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -71,7 +71,7 @@ function makeInputOnChange (index) {
     simulateProgress(
       function (percent) {
         ids.forEach(function (id, index) {
-          let status = `${percent}% done uploading ${names[index]}`
+          let status = `Uploading ${names[index]}`
           ed.updatePlaceholder(id, status, percent)
         })
       },
@@ -108,7 +108,7 @@ function onShareUrlDemo (share) {
 
   simulateProgress(
     function (percent) {
-      const status = `${percent}% done sharing ${url}`
+      const status = `Sharing ${url}`
       ed.updatePlaceholder(block, status, percent)
     },
     function () {

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -133,7 +133,7 @@ function onShareUrlDemo (share) {
 function simulateProgress (progress, complete) {
   let percent = 0
   let animate = function () {
-    percent++
+    percent += 0.5
     if (percent < 100) {
       // Loop animation
       requestAnimationFrame(animate)

--- a/src/commands/ed-commands.js
+++ b/src/commands/ed-commands.js
@@ -15,7 +15,6 @@ const ed_upload_image =
     { group: 'ed_block'
     , rank: 100
     , class: 'EdMenuText'
-    , select: 'disable'
     , display:
       { type: 'label'
       , label: 'Upload Image'

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -1,5 +1,6 @@
 import {CommandSet} from 'prosemirror/src/edit'
 import edCommands from './ed-commands'
+import {joinBackward} from './schema-commands'
 
 let commands = CommandSet.default
   .add(edCommands)
@@ -7,6 +8,7 @@ let commands = CommandSet.default
     { 'code:toggle': {menu: null}
     , joinUp: {menu: null}
     , selectParentNode: {menu: null}
+    , joinBackward
     }
   )
 

--- a/src/components/fold-media.js
+++ b/src/components/fold-media.js
@@ -32,7 +32,7 @@ class FoldMedia extends React.Component {
         , maxWidth: 800
         }
       }
-    , ( block
+    , (block
       ? el(Media, {initialBlock: block, id: block.id})
       : this.renderAddMedia()
       )

--- a/src/components/fold-media.js
+++ b/src/components/fold-media.js
@@ -19,11 +19,11 @@ class FoldMedia extends React.Component {
     }
     const {store} = context
     store.on('fold.media.change', (block) => {
-      this.setState({block, id: block.id})
+      this.setState({block})
     })
   }
   render () {
-    const {block, id} = this.state
+    const {block} = this.state
     return el('div'
     , { className: 'FoldMedia'
       , style:
@@ -32,8 +32,8 @@ class FoldMedia extends React.Component {
         , maxWidth: 800
         }
       }
-    , (block
-      ? el(Media, {initialBlock: block, id})
+    , ( block
+      ? el(Media, {initialBlock: block, id: block.id})
       : this.renderAddMedia()
       )
     )

--- a/src/components/media.js
+++ b/src/components/media.js
@@ -1,8 +1,9 @@
-import {createElement as el} from 'react'
+import React, {createElement as el} from 'react'
 
 import Placeholder from './placeholder'
 import AttributionEditor from './attribution-editor'
 import Title from './title'
+import rebassTheme from './rebass-theme'
 
 const Components =
   { placeholder: Placeholder
@@ -10,8 +11,28 @@ const Components =
   , attribution: AttributionEditor
   }
 
-export default function Media (props) {
-  const {type} = props.initialBlock
-  let Component = Components[type] || Components.attribution
-  return el(Component, props)
+class Media extends React.Component {
+  getChildContext () {
+    return (
+      { imgfloConfig: (this.context.imgfloConfig || this.props.imgfloConfig)
+      , store: (this.context.store || this.props.store)
+      , rebass: rebassTheme
+      }
+    )
+  }
+  render () {
+    const {type} = this.props.initialBlock
+    let Component = Components[type] || Components.attribution
+    return el(Component, this.props)
+  }
 }
+Media.contextTypes =
+  { imgfloConfig: React.PropTypes.object
+  , store: React.PropTypes.object
+  }
+Media.childContextTypes =
+  { imgfloConfig: React.PropTypes.object
+  , rebass: React.PropTypes.object
+  , store: React.PropTypes.object
+  }
+export default React.createFactory(Media)

--- a/src/components/placeholder.js
+++ b/src/components/placeholder.js
@@ -1,14 +1,13 @@
 import {createElement as el} from 'react'
 import Message from 'rebass/dist/Message'
+import Progress from 'rebass/dist/Progress'
 
 export default function Placeholder (props) {
   const {metadata} = props.initialBlock
   if (!metadata) {
     return el('div', {className: 'Placeholder'})
   }
-  const status = metadata.status || ''
-  // const value = metadata.progress
-  // const mode = metadata.progress != null ? 'determinate' : 'indeterminate'
+  const {status, progress} = metadata
 
   return el('div'
   , {className: 'Placeholder'}
@@ -19,5 +18,16 @@ export default function Placeholder (props) {
       }
     , status
     )
+  , makeProgress(progress)
+  )
+}
+
+function makeProgress (progress) {
+  if (progress == null) return
+  return el(Progress
+  , { value: progress/100
+    , theme: 'info'
+    , style: {marginTop: 16}
+    }
   )
 }

--- a/src/components/placeholder.js
+++ b/src/components/placeholder.js
@@ -36,7 +36,7 @@ Placeholder.contextTypes =
 function makeProgress (progress) {
   if (progress == null) return
   return el(Progress
-  , { value: progress/100
+  , { value: progress / 100
     , theme: 'info'
     , style: {marginTop: 16}
     }

--- a/src/components/placeholder.js
+++ b/src/components/placeholder.js
@@ -15,11 +15,10 @@ export default function Placeholder (props, context) {
   return el('div'
   , {className: 'Placeholder'}
   , el(Message
-    , { className: 'Placeholder-status'
-      , theme: 'info'
+    , { theme: 'info'
       , style: {marginBottom: 0}
       }
-    , status
+    , el('span', {className: 'Placeholder-status'}, status)
     , el(Space
       , {auto: true, x: 1}
       )

--- a/src/components/placeholder.js
+++ b/src/components/placeholder.js
@@ -1,9 +1,12 @@
-import {createElement as el} from 'react'
+import React, {createElement as el} from 'react'
 import Message from 'rebass/dist/Message'
 import Progress from 'rebass/dist/Progress'
+import Space from 'rebass/dist/Space'
+import Close from 'rebass/dist/Close'
 
-export default function Placeholder (props) {
-  const {metadata} = props.initialBlock
+export default function Placeholder (props, context) {
+  const {store} = context
+  const {metadata, id} = props.initialBlock
   if (!metadata) {
     return el('div', {className: 'Placeholder'})
   }
@@ -17,10 +20,18 @@ export default function Placeholder (props) {
       , style: {marginBottom: 0}
       }
     , status
+    , el(Space
+      , {auto: true, x: 1}
+      )
+    , el(Close
+      , {onClick: makeCancel(store, id)}
+      )
     )
   , makeProgress(progress)
   )
 }
+Placeholder.contextTypes =
+  { store: React.PropTypes.object }
 
 function makeProgress (progress) {
   if (progress == null) return
@@ -30,4 +41,10 @@ function makeProgress (progress) {
     , style: {marginTop: 16}
     }
   )
+}
+
+function makeCancel (store, id) {
+  return function () {
+    store.routeChange('PLACEHOLDER_CANCEL', id)
+  }
 }

--- a/src/ed.js
+++ b/src/ed.js
@@ -108,7 +108,7 @@ export default class Ed {
         this._placeholderCancel(payload)
         break
       default:
-        throw new Error(`ed.routeChange ${type} does not exist`)
+        throw new Error(`ed.routeChange '${type}' does not exist`)
     }
   }
   _editableInitialize (editableView) {

--- a/src/ed.js
+++ b/src/ed.js
@@ -9,6 +9,8 @@ import determineFold from './convert/determine-fold'
 
 import App from './components/app'
 
+function noop () {}
+
 
 export default class Ed {
   constructor (options) {
@@ -46,6 +48,7 @@ export default class Ed {
     options.onChange = this.routeChange.bind(this)
     this.onShareUrl = options.onShareUrl
     this.onShareFile = options.onShareFile
+    this.onPlaceholderCancel = options.onPlaceholderCancel || noop
 
     // Setup main DOM structure
     this.container = options.container
@@ -101,7 +104,11 @@ export default class Ed {
         this.trigger('fold.media.change', payload)
         this.trigger('change')
         break
+      case 'PLACEHOLDER_CANCEL':
+        this._placeholderCancel(payload)
+        break
       default:
+        throw new Error(`ed.routeChange ${type} does not exist`)
         break
     }
   }
@@ -232,6 +239,23 @@ export default class Ed {
       this.trigger('fold.media.change', block)
     }
   }
+  _placeholderCancel (id) {
+    let block = this.getBlock(id)
+    if (!block) {
+      throw new Error('Can not cancel this placeholder block')
+    }
+    if (block.type !== 'placeholder') {
+      throw new Error('Block is not a placeholder block')
+    }
+    const content = this.getContent()
+    const index = getIndexWithId(content, id)
+    // MUTATION
+    content.splice(index, 1)
+    // Render
+    this._setMergedContent(content)
+    // Event
+    this.onPlaceholderCancel(id)
+  }
   getContent () {
     const doc = this.pm.getContent()
     const content = DocToGrid(doc, this._content)
@@ -252,10 +276,8 @@ export default class Ed {
   _setMergedContent (mergedContent) {
     this._initializeContent(mergedContent)
     const {media, content} = determineFold(mergedContent)
-    if (media) {
-      this._foldMedia = media.id
-      this.trigger('fold.media.change', media)
-    }
+    this._foldMedia = (media ? media.id : null)
+    this.trigger('fold.media.change', media)
     let doc = GridToDoc(content)
     // Cache selection to restore after DOM update
     let selection = fixSelection(this.pm.selection, doc)

--- a/src/ed.js
+++ b/src/ed.js
@@ -109,7 +109,6 @@ export default class Ed {
         break
       default:
         throw new Error(`ed.routeChange ${type} does not exist`)
-        break
     }
   }
   _editableInitialize (editableView) {

--- a/test/ed.js
+++ b/test/ed.js
@@ -271,7 +271,7 @@ describe('Ed', function () {
           ]
         expect(content).to.deep.equal(expected)
       })
-      
+
       it('does not have cancelled placeholder', function () {
         const ids = ed.insertPlaceholders(1, 1)
         ed._placeholderCancel(ids[0])

--- a/test/ed.js
+++ b/test/ed.js
@@ -225,6 +225,21 @@ describe('Ed', function () {
       expect(content[3].type.name).to.equal('paragraph')
     })
 
+    it('cancels placeholder', function () {
+      const ids = ed.insertPlaceholders(1, 1)
+      ed._placeholderCancel(ids[0])
+
+      expect(ed._foldMedia).to.be.null
+      const content = ed.editableView.pm.doc.content.content
+      expect(content.length).to.equal(3)
+      expect(content[0].textContent).to.equal('Title')
+      expect(content[0].type.name).to.equal('heading')
+      expect(content[1].textContent).to.equal('Text 1')
+      expect(content[1].type.name).to.equal('paragraph')
+      expect(content[2].textContent).to.equal('Text 2')
+      expect(content[2].type.name).to.equal('paragraph')
+    })
+
     describe('Getting content', function () {
       it('outputs expected content', function () {
         const ids = ed.insertPlaceholders(1, 2)
@@ -251,6 +266,18 @@ describe('Ed', function () {
             , type: 'image'
             , cover: {src: '...b.jpg'}
             }
+          , { type: 'text', html: '<p>Text 1</p>' }
+          , { type: 'text', html: '<p>Text 2</p>' }
+          ]
+        expect(content).to.deep.equal(expected)
+      })
+      
+      it('does not have cancelled placeholder', function () {
+        const ids = ed.insertPlaceholders(1, 1)
+        ed._placeholderCancel(ids[0])
+        const content = ed.getContent()
+        const expected =
+          [ { type: 'h1', html: '<h1>Title</h1>' }
           , { type: 'text', html: '<p>Text 1</p>' }
           , { type: 'text', html: '<p>Text 2</p>' }
           ]

--- a/test/plugins/widget.js
+++ b/test/plugins/widget.js
@@ -54,17 +54,19 @@ describe('PluginWidget', function () {
 
     it('has mounted widget', function () {
       const widget = PluginWidget.widgets['0000']
+      const status = widget.el.querySelector('.Placeholder-status')
       expect(widget).to.exist
       expect(widget.type).to.equal('placeholder')
       expect(widget.el.firstChild.className).to.equal('Placeholder')
-      expect(widget.el.textContent).to.equal('Status')
+      expect(status.textContent).to.equal('Status')
     })
 
     it('updates widget props via setContent', function (done) {
       ed.on('media.update', function () {
         const widget = PluginWidget.widgets['0000']
+        const status = widget.el.querySelector('.Placeholder-status')
         expect(widget.type).to.equal('placeholder')
-        expect(widget.el.textContent).to.equal('Status changed')
+        expect(status.textContent).to.equal('Status changed')
         done()
       })
       ed.setContent([
@@ -78,8 +80,9 @@ describe('PluginWidget', function () {
     it('updates widget props via updatePlaceholder', function (done) {
       ed.on('media.update', function () {
         const widget = PluginWidget.widgets['0000']
+        const status = widget.el.querySelector('.Placeholder-status')
         expect(widget.type).to.equal('placeholder')
-        expect(widget.el.textContent).to.equal('Status changed')
+        expect(status.textContent).to.equal('Status changed')
         done()
       })
       ed.updatePlaceholder('0000', 'Status changed')


### PR DESCRIPTION
- Placeholder progress bar
  - `progress` 0-100 with `ed.updatePlaceholder(id, status, progress)` or `ed.setContent([{id, metadata: {status, progress}}])`
- NEW -- **X** button on the Placeholder component triggers `options.onPlaceholderCancel(id)`
  - When that is hit, `ed.getContent()` will already have removed the cancelled placeholder block
- Delete from under media block ignored 
