### PR TITLE
ios getContent fix #105

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## dev
 
+## 0.6.2 - 2016-03-20
+
+* Hotfix `ed.getContent()` on :iphone: (#105)
+
 ## 0.6.1 - 2016-03-18
 
 * Demo starts blank to test the initial flow

--- a/src/convert/doc-to-grid.js
+++ b/src/convert/doc-to-grid.js
@@ -2,7 +2,9 @@ import {toDOM} from 'prosemirror/src/format'
 import {isMediaType} from './types'
 
 export default function (doc, apiContentMap) {
-  const dom = toDOM(doc)
+  const fragment = toDOM(doc)
+  const dom = document.createElement('div')
+  dom.appendChild(fragment)
   let currentContent = []
   for (let i = 0, len = dom.children.length; i < len; i++) {
     const child = dom.children[i]


### PR DESCRIPTION
iOS doesn't have `ParentNode` props on fragments
