### PR TITLE
placeholder block metadata.failed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## dev
 
+## 0.7.0
+
+* BREAKING - changed arguments for `ed.updatePlaceholder` to `id, {status, progress, errored}`
+  * Placholder block `metadata.errored` will show in red and have an "×" button to remove
+
 ## 0.6.2 - 2016-03-20
 
 * Hotfix `ed.getContent()` on :iphone: (#105)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,8 @@
 
 ## 0.7.0
 
-* BREAKING - changed arguments for `ed.updatePlaceholder` to `id, {status, progress, errored}`
-  * Placholder block `metadata.errored` will show in red and have an "×" button to remove
+* BREAKING - changed arguments for `ed.updatePlaceholder` to `id, {status, progress, failed}`
+  * Placholder block `metadata.failed` will show in red and have an "×" button to remove
 
 ## 0.6.2 - 2016-03-20
 

--- a/demo/fixture.js
+++ b/demo/fixture.js
@@ -605,7 +605,7 @@ let post = {
     , type: 'placeholder'
     , metadata:
       { status: 'Hmmm...'
-      , errored: true
+      , failed: true
       }
     },
     {

--- a/demo/fixture.js
+++ b/demo/fixture.js
@@ -604,7 +604,7 @@ let post = {
     { id: '0000-failed'
     , type: 'placeholder'
     , metadata:
-      { status: 'Hmmm...' 
+      { status: 'Hmmm...'
       , errored: true
       }
     },

--- a/demo/fixture.js
+++ b/demo/fixture.js
@@ -544,7 +544,8 @@ let sharing = {
   id: 'uuid-share-00',
   type: 'placeholder',
   metadata: {
-    status: 'Sharing... https://thegrid.io/#8'
+    status: 'Sharing... https://thegrid.io/#8',
+    progress: 67
   }
 }
 
@@ -600,6 +601,13 @@ let post = {
     article,
     tweet,
     sharing,
+    { id: '0000-failed'
+    , type: 'placeholder'
+    , metadata:
+      { status: 'Hmmm...' 
+      , errored: true
+      }
+    },
     {
       'id': 'abc-00000000-h3',
       'type': 'h3',

--- a/src/components/placeholder.js
+++ b/src/components/placeholder.js
@@ -11,7 +11,7 @@ export default function Placeholder (props, context) {
     return el('div', {className: 'Placeholder'})
   }
   const {status, progress, errored} = metadata
-  
+
   const theme = (errored === true ? 'error' : 'info')
 
   return el('div'

--- a/src/components/placeholder.js
+++ b/src/components/placeholder.js
@@ -10,12 +10,14 @@ export default function Placeholder (props, context) {
   if (!metadata) {
     return el('div', {className: 'Placeholder'})
   }
-  const {status, progress} = metadata
+  const {status, progress, errored} = metadata
+  
+  const theme = (errored === true ? 'error' : 'info')
 
   return el('div'
-  , {className: 'Placeholder'}
+  , {className: `Placeholder Placeholder-${theme}`}
   , el(Message
-    , { theme: 'info'
+    , { theme
       , style: {marginBottom: 0}
       }
     , el('span', {className: 'Placeholder-status'}, status)
@@ -26,18 +28,18 @@ export default function Placeholder (props, context) {
       , {onClick: makeCancel(store, id)}
       )
     )
-  , makeProgress(progress)
+  , makeProgress(progress, theme)
   )
 }
 Placeholder.contextTypes =
   { store: React.PropTypes.object }
 
-function makeProgress (progress) {
+function makeProgress (progress, theme) {
   if (progress == null) return
   return el(Progress
   , { value: progress / 100
-    , theme: 'info'
     , style: {marginTop: 16}
+    , theme
     }
   )
 }

--- a/src/components/placeholder.js
+++ b/src/components/placeholder.js
@@ -10,9 +10,9 @@ export default function Placeholder (props, context) {
   if (!metadata) {
     return el('div', {className: 'Placeholder'})
   }
-  const {status, progress, errored} = metadata
+  const {status, progress, failed} = metadata
 
-  const theme = (errored === true ? 'error' : 'info')
+  const theme = (failed === true ? 'error' : 'info')
 
   return el('div'
   , {className: `Placeholder Placeholder-${theme}`}

--- a/src/ed.js
+++ b/src/ed.js
@@ -242,7 +242,7 @@ export default class Ed {
     this._insertBlocks(index, toInsert)
     return ids
   }
-  updatePlaceholder (id, {status, progress, errored}) {
+  updatePlaceholder (id, metadata) {
     let block = this.getBlock(id)
     if (!block) {
       throw new Error('Can not update this placeholder block')
@@ -251,6 +251,7 @@ export default class Ed {
       throw new Error('Block is not a placeholder block')
     }
     // Mutation
+    const {status, progress, errored} = metadata
     if (status != null) block.metadata.status = status
     if (progress != null) block.metadata.progress = progress
     if (errored != null) block.metadata.errored = errored

--- a/src/ed.js
+++ b/src/ed.js
@@ -242,7 +242,7 @@ export default class Ed {
     this._insertBlocks(index, toInsert)
     return ids
   }
-  updatePlaceholder (id, status, progress) {
+  updatePlaceholder (id, {status, progress, errored}) {
     let block = this.getBlock(id)
     if (!block) {
       throw new Error('Can not update this placeholder block')
@@ -253,6 +253,7 @@ export default class Ed {
     // Mutation
     if (status != null) block.metadata.status = status
     if (progress != null) block.metadata.progress = progress
+    if (errored != null) block.metadata.errored = errored
     // Let content widgets know to update
     this.trigger('media.update')
     // Let fold media know to update

--- a/src/ed.js
+++ b/src/ed.js
@@ -251,10 +251,10 @@ export default class Ed {
       throw new Error('Block is not a placeholder block')
     }
     // Mutation
-    const {status, progress, errored} = metadata
+    const {status, progress, failed} = metadata
     if (status != null) block.metadata.status = status
     if (progress != null) block.metadata.progress = progress
-    if (errored != null) block.metadata.errored = errored
+    if (failed != null) block.metadata.failed = failed
     // Let content widgets know to update
     this.trigger('media.update')
     // Let fold media know to update

--- a/test/plugins/widget.js
+++ b/test/plugins/widget.js
@@ -61,7 +61,7 @@ describe('PluginWidget', function () {
       expect(status.textContent).to.equal('Status')
     })
 
-    it('updates widget props via setContent', function (done) {
+    it('updates placeholder widget status via setContent', function (done) {
       ed.on('media.update', function () {
         const widget = PluginWidget.widgets['0000']
         const status = widget.el.querySelector('.Placeholder-status')
@@ -73,6 +73,22 @@ describe('PluginWidget', function () {
         { id: '0000'
         , type: 'placeholder'
         , metadata: {status: 'Status changed'}
+        }
+      ])
+    })
+
+    it('updates placeholder widget errored via setContent', function (done) {
+      const widget = PluginWidget.widgets['0000']
+      const el = widget.el.querySelector('.Placeholder')
+      ed.on('media.update', function () {
+        expect(el.classList.contains('Placeholder-error')).to.be.true
+        done()
+      })
+      expect(el.classList.contains('Placeholder-error')).to.be.false
+      ed.setContent([
+        { id: '0000'
+        , type: 'placeholder'
+        , metadata: {errored: true}
         }
       ])
     })
@@ -89,23 +105,14 @@ describe('PluginWidget', function () {
     })
 
     it('updates placeholder widget errored true via updatePlaceholder', function (done) {
+      const widget = PluginWidget.widgets['0000']
+      const el = widget.el.querySelector('.Placeholder')
       ed.on('media.update', function () {
-        const widget = PluginWidget.widgets['0000']
-        const el = widget.el.querySelector('.Placeholder')
         expect(el.classList.contains('Placeholder-error')).to.be.true
         done()
       })
+      expect(el.classList.contains('Placeholder-error')).to.be.false
       ed.updatePlaceholder('0000', {errored: true})
-    })
-
-    it('updates placeholder widget errored false via updatePlaceholder', function (done) {
-      ed.on('media.update', function () {
-        const widget = PluginWidget.widgets['0000']
-        const el = widget.el.querySelector('.Placeholder')
-        expect(el.classList.contains('Placeholder-error')).to.be.false
-        done()
-      })
-      ed.updatePlaceholder('0000', {errored: false})
     })
 
     it('changes widget type via setContent', function (done) {

--- a/test/plugins/widget.js
+++ b/test/plugins/widget.js
@@ -77,7 +77,7 @@ describe('PluginWidget', function () {
       ])
     })
 
-    it('updates placeholder widget errored via setContent', function (done) {
+    it('updates placeholder widget failed via setContent', function (done) {
       const widget = PluginWidget.widgets['0000']
       const el = widget.el.querySelector('.Placeholder')
       ed.on('media.update', function () {
@@ -88,7 +88,7 @@ describe('PluginWidget', function () {
       ed.setContent([
         { id: '0000'
         , type: 'placeholder'
-        , metadata: {errored: true}
+        , metadata: {failed: true}
         }
       ])
     })
@@ -104,7 +104,7 @@ describe('PluginWidget', function () {
       ed.updatePlaceholder('0000', {status: 'Status changed'})
     })
 
-    it('updates placeholder widget errored true via updatePlaceholder', function (done) {
+    it('updates placeholder widget failed true via updatePlaceholder', function (done) {
       const widget = PluginWidget.widgets['0000']
       const el = widget.el.querySelector('.Placeholder')
       ed.on('media.update', function () {
@@ -112,7 +112,7 @@ describe('PluginWidget', function () {
         done()
       })
       expect(el.classList.contains('Placeholder-error')).to.be.false
-      ed.updatePlaceholder('0000', {errored: true})
+      ed.updatePlaceholder('0000', {failed: true})
     })
 
     it('changes widget type via setContent', function (done) {

--- a/test/plugins/widget.js
+++ b/test/plugins/widget.js
@@ -57,7 +57,7 @@ describe('PluginWidget', function () {
       const status = widget.el.querySelector('.Placeholder-status')
       expect(widget).to.exist
       expect(widget.type).to.equal('placeholder')
-      expect(widget.el.firstChild.className).to.equal('Placeholder')
+      expect(widget.el.firstChild.classList.contains('Placeholder')).to.be.true
       expect(status.textContent).to.equal('Status')
     })
 
@@ -77,7 +77,7 @@ describe('PluginWidget', function () {
       ])
     })
 
-    it('updates widget props via updatePlaceholder', function (done) {
+    it('updates placeholder widget status via updatePlaceholder', function (done) {
       ed.on('media.update', function () {
         const widget = PluginWidget.widgets['0000']
         const status = widget.el.querySelector('.Placeholder-status')
@@ -85,7 +85,27 @@ describe('PluginWidget', function () {
         expect(status.textContent).to.equal('Status changed')
         done()
       })
-      ed.updatePlaceholder('0000', 'Status changed')
+      ed.updatePlaceholder('0000', {status: 'Status changed'})
+    })
+
+    it('updates placeholder widget errored true via updatePlaceholder', function (done) {
+      ed.on('media.update', function () {
+        const widget = PluginWidget.widgets['0000']
+        const el = widget.el.querySelector('.Placeholder')
+        expect(el.classList.contains('Placeholder-error')).to.be.true
+        done()
+      })
+      ed.updatePlaceholder('0000', {errored: true})
+    })
+
+    it('updates placeholder widget errored false via updatePlaceholder', function (done) {
+      ed.on('media.update', function () {
+        const widget = PluginWidget.widgets['0000']
+        const el = widget.el.querySelector('.Placeholder')
+        expect(el.classList.contains('Placeholder-error')).to.be.false
+        done()
+      })
+      ed.updatePlaceholder('0000', {errored: false})
     })
 
     it('changes widget type via setContent', function (done) {


### PR DESCRIPTION
- BREAKING - changed arguments for `ed.updatePlaceholder` to `id, {status, progress, failed}`
  - Placholder block `metadata.failed = true` will show in red and have an "×" button to remove

@hannesstruss does changing `updatePlaceholder` arguments like this look OK?
