### PR TITLE
ed.setCoverPreview

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,9 +3,9 @@
 * New UI component: NavItemConfirm
 * "Remove block" in block "..." dropdown now asks for confirmation
 * FIX -- removing fold media fixed
-* NEW -- `ed.setCoverPreview(id, src)`
+* NEW -- `ed.setCoverPreview(id, src)` (#92)
   * `src` is a `blob:` or `data:` url for the local image to show while uploading / measuring
-  * Preview takes precidence over content array version of `cover.src`
+  * Preview takes precedence over content array version of `cover.src`
   * Setting src `null` will show real cover
 
 ## 0.7.3 - 2016-03-24

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 * New UI component: NavItemConfirm
 * "Remove block" in block "..." dropdown now asks for confirmation
 * FIX -- removing fold media fixed
+* NEW -- `ed.setCoverPreview(id, src)`
+  * `src` is a `blob:` or `data:` url for the local image to show while uploading / measuring
+  * Preview takes precidence over content array version of `cover.src`
+  * Setting src `null` will show real cover
 
 ## 0.7.3 - 2016-03-24
 

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -63,12 +63,18 @@ function makeInputOnChange (index) {
     const input = event.target
     let names = []
     for (let i = 0, len = input.files.length; i < len; i++) {
-      let file = input.files[i]
+      const file = input.files[i]
       names.push(file.name)
     }
 
     // Insert placeholder blocks into content
     const ids = ed.insertPlaceholders(index, names.length)
+
+    for (let i = 0, len = input.files.length; i < len; i++) {
+      const file = input.files[i]
+      const url = URL.createObjectURL(file)
+      ed.setCoverPreview(ids[i], url)
+    }
 
     console.log('app uploads files now and calls ed.updatePlaceholder with updates')
 
@@ -85,11 +91,6 @@ function makeInputOnChange (index) {
             { id
             , type: 'image'
             , metadata: {title: names[index]}
-            , cover:
-              { src: 'http://meemoo.org/images/meemoo-illo-by-jyri-pieniniemi-400.png'
-              , width: 400
-              , height: 474
-              }
             }
           )
         })

--- a/src/components/attribution-editor.js
+++ b/src/components/attribution-editor.js
@@ -71,10 +71,9 @@ class AttributionEditor extends React.Component {
     }
     if (!src) return
     let props = {src, width, height}
-    return el(
-      'div'
-      , {className: 'AttributionEditor-cover'}
-      , el(Image, props)
+    return el('div'
+    , {className: 'AttributionEditor-cover'}
+    , el(Image, props)
     )
   }
   onChange (path, value) {

--- a/src/components/attribution-editor.js
+++ b/src/components/attribution-editor.js
@@ -28,7 +28,7 @@ class AttributionEditor extends React.Component {
   }
   render () {
     const {block} = this.state
-    const {type, cover, metadata} = block
+    const {type, metadata} = block
     const schema = blockMetaSchema[type] || blockMetaSchema.default
 
     const menus = renderMenus(schema, metadata, this.onChange.bind(this), this.onMoreClick.bind(this))
@@ -36,7 +36,7 @@ class AttributionEditor extends React.Component {
     return el(
       'div'
       , { className: 'AttributionEditor' }
-      , renderCover(cover)
+      , this.renderCover()
       , el(
         'div'
         , { className: 'AttributionEditor-metadata' }
@@ -51,6 +51,30 @@ class AttributionEditor extends React.Component {
         'div'
         , { style: {clear: 'both'} }
       )
+    )
+  }
+  renderCover () {
+    const {block} = this.state
+    if (!block) return
+    const {id, cover} = block
+    const store = (this.context.store || this.props.store)
+    const preview = store.getCoverPreview(id)
+    if (!cover && !preview) return
+    let src, width, height
+    if (cover) {
+      src = cover.src
+      width = cover.width
+      height = cover.height
+    }
+    if (preview) {
+      src = preview
+    }
+    if (!src) return
+    let props = {src, width, height}
+    return el(
+      'div'
+      , {className: 'AttributionEditor-cover'}
+      , el(Image, props)
     )
   }
   onChange (path, value) {
@@ -118,18 +142,6 @@ function makeChange (path, onChange) {
     const {value} = event.target
     onChange(path, value)
   }
-}
-
-function renderCover (cover) {
-  if (!cover) return
-  let {src, width, height} = cover
-  if (!src) return
-  let props = {src, width, height}
-  return el(
-    'div'
-    , {className: 'AttributionEditor-cover'}
-    , el(Image, props)
-  )
 }
 
 function renderFields (schema, metadata = {}, onChange) {

--- a/src/components/placeholder.js
+++ b/src/components/placeholder.js
@@ -1,4 +1,5 @@
 import React, {createElement as el} from 'react'
+import Image from './image'
 import Message from 'rebass/dist/Message'
 import Progress from 'rebass/dist/Progress'
 import Space from 'rebass/dist/Space'
@@ -21,6 +22,7 @@ export default function Placeholder (props, context) {
       , style: {marginBottom: 0}
       }
     , el('span', {className: 'Placeholder-status'}, status)
+    , makePreview(id, store)
     , el(Space
       , {auto: true, x: 1}
       )
@@ -33,6 +35,21 @@ export default function Placeholder (props, context) {
 }
 Placeholder.contextTypes =
   { store: React.PropTypes.object }
+
+function makePreview (id, store) {
+  const preview = store.getCoverPreview(id)
+  if (!preview) return
+  return el('div'
+  , { style:
+      { width: 72
+      , height: 72
+      , display: 'inline-block'
+      , margin: '0px 16px'
+      }
+    }
+  , el(Image, {src: preview})
+  )
+}
 
 function makeProgress (progress, theme) {
   if (progress == null) return

--- a/src/convert/determine-fold.js
+++ b/src/convert/determine-fold.js
@@ -1,12 +1,16 @@
 import {isMediaType} from './types'
 
-export default function determineFold (items) {
+export default function determineFold (items, previews) {
   let media = null
   let content = []
   for (let i = 0, len = items.length; i < len; i++) {
     const item = items[i]
-    const {type, cover, metadata} = item
+    const {id, type, cover, metadata} = item
     if (!media && isMediaType(type) && cover && cover.src) {
+      media = item
+      continue
+    }
+    if (!media && isMediaType(type) && previews && previews[id]) {
       media = item
       continue
     }

--- a/src/ed.js
+++ b/src/ed.js
@@ -37,8 +37,9 @@ export default class Ed {
     // Initialize store
     this._events = {}
     this._content = {}
+    this._coverPreviews = {}
     this._initializeContent(options.initialContent)
-    const {media, content} = determineFold(options.initialContent)
+    const {media, content} = determineFold(options.initialContent, this._coverPreviews)
     this._foldMedia = (media ? media.id : null)
     options.initialMedia = media
     options.initialContent = content
@@ -306,6 +307,17 @@ export default class Ed {
     // Event
     this.onPlaceholderCancel(id)
   }
+  setCoverPreview (id, src) {
+    const block = this._content[id]
+    if (!block) {
+      throw new Error('Can not set image preview for block id that does not exist')
+    }
+    this._coverPreviews[id] = src
+    this.trigger('fold.media.change', block)
+  }
+  getCoverPreview (id) {
+    return this._coverPreviews[id]
+  }
   getContent () {
     const doc = this.pm.getContent()
     const content = DocToGrid(doc, this._content)
@@ -325,7 +337,7 @@ export default class Ed {
   }
   _setMergedContent (mergedContent) {
     this._initializeContent(mergedContent)
-    const {media, content} = determineFold(mergedContent)
+    const {media, content} = determineFold(mergedContent, this._coverPreviews)
     this._foldMedia = (media ? media.id : null)
     this.trigger('fold.media.change', media)
     let doc = GridToDoc(content)

--- a/test/convert/determine-fold.js
+++ b/test/convert/determine-fold.js
@@ -102,4 +102,28 @@ describe('determineFold', function () {
       expect(folded).to.deep.equal(expected)
     })
   })
+
+  describe('with local (blob/data) image preview', function () {
+    const fixture =
+      [ { id: '0000', type: 'image' }
+      , { type: 'h1', html: '<h1>heading 1</h1>' }
+      , { type: 'text', html: '<p>paragraph 0</p>' }
+      , { type: 'text', html: '<p>paragraph 1</p>' }
+      ]
+    const previews = {'0000': 'blob://...'}
+    const expected =
+      { media:
+        { id: '0000', type: 'image' }
+      , content:
+        [ { type: 'h1', html: '<h1>heading 1</h1>' }
+        , { type: 'text', html: '<p>paragraph 0</p>' }
+        , { type: 'text', html: '<p>paragraph 1</p>' }
+        ]
+      }
+
+    it('correctly finds fold media', function () {
+      const folded = determineFold(fixture, previews)
+      expect(folded).to.deep.equal(expected)
+    })
+  })
 })


### PR DESCRIPTION
- NEW -- `ed.setCoverPreview(id, src)`
  - `src` is a `blob:` or `data:` url for the local image to show while uploading / measuring
  - Preview takes precedence over content array version of `cover.src`
  - Setting src `null` will show real cover
