### PR TITLE
remove outline for dropdown toggle

### DIFF
--- a/src/components/dropdown-group.js
+++ b/src/components/dropdown-group.js
@@ -61,7 +61,8 @@ class DropdownGroup extends React.Component {
           , inverted: false
           , style:
             { borderWidth: 0
-            , boxShadow: 'none'
+            , boxShadow: 'none',
+              outline: 'none'
             }
           , rounded: false
           , title: `Edit ${label}`

--- a/src/components/dropdown-group.js
+++ b/src/components/dropdown-group.js
@@ -61,8 +61,8 @@ class DropdownGroup extends React.Component {
           , inverted: false
           , style:
             { borderWidth: 0
-            , boxShadow: 'none',
-              outline: 'none'
+            , boxShadow: 'none'
+            , outline: 'none'
             }
           , rounded: false
           , title: `Edit ${label}`


### PR DESCRIPTION
Hey! Just saw this while testing.

Current state:
![screen shot 2016-05-24 at 16 40 40](https://cloud.githubusercontent.com/assets/773681/15512953/c230ff62-21e2-11e6-9b63-374fc7d4bdb4.png)

---

"Fixed" version:
![screen shot 2016-05-24 at 16 40 34](https://cloud.githubusercontent.com/assets/773681/15512954/c2328ea4-21e2-11e6-84cb-b7e2207187b1.png)

Unless this was on purpose. The component is named "ButtonOutline" already.
