### PR TITLE
Feature/ez focus

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 * Space media with blank `p`: easier focus on mobile
 * Skip empty blocks with `getContent` (#204)
+* Focus on load
 
 ## 0.12.3 - 2016-05-26
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## dev
 
+* Skip empty blocks with `getContent` (#204)
 ## 0.12.3 - 2016-05-26
 
 * Add label to Author & Publisher dropdown (#203)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 ## dev
 
+* Space media with blank `p`: easier focus on mobile
 * Skip empty blocks with `getContent` (#204)
+
 ## 0.12.3 - 2016-05-26
 
 * Add label to Author & Publisher dropdown (#203)

--- a/src/convert/doc-to-grid.js
+++ b/src/convert/doc-to-grid.js
@@ -25,9 +25,12 @@ export default function (doc, apiContentMap) {
     if (!apiBlock) {
       apiBlock = isMedia ? {id, type} : {type}
     }
-    // TODO massage media types that need it
     if (!isMedia) {
       apiBlock.html = child.outerHTML
+      // Skip empty blocks in output content
+      if (isEmpty(type, apiBlock.html)) {
+        continue
+      }
     }
     if (isMedia) {
       const html = metaToHtml(apiBlock)
@@ -71,4 +74,12 @@ export function metaToHtml (block) {
   if (schema && schema.makeHtml) {
     return schema.makeHtml(block.metadata, block.cover)
   }
+}
+
+function isEmpty (type, html) {
+  if (type === 'text' && html === '<p></p>') return true
+  if (type === 'h1' && html === '<h1></h1>') return true
+  if (type === 'h2' && html === '<h2></h2>') return true
+  if (type === 'h3' && html === '<h3></h3>') return true
+  return false
 }

--- a/src/convert/grid-to-doc.js
+++ b/src/convert/grid-to-doc.js
@@ -17,6 +17,7 @@ export default function (items, schema = EdSchemaFull) {
   if (unstarred.length > 0) {
     const hr = document.createElement('hr')
     container.appendChild(hr)
+    unstarred = spaceContent(unstarred)
     elements = itemsToEls(unstarred)
     elements.forEach(function (el) {
       if (el) container.appendChild(el)

--- a/src/convert/space-content.js
+++ b/src/convert/space-content.js
@@ -1,5 +1,24 @@
+import {isMediaType} from './types'
+
 export default function spaceContent (items) {
-  let spacedItems = items.slice()
+  let spacedItems = []
+  for (let i = 0, len = items.length; i < len; i++) {
+    const item = items[i]
+    const currentIsMedia = isMediaType(item.type)
+    if (i === 0 && currentIsMedia) {
+      spacedItems.push(makeEmptyTextBlock())
+    }
+    spacedItems.push(item)
+    const next = items[i + 1]
+    if (currentIsMedia) {
+      if (next && isMediaType(next.type)) {
+        spacedItems.push(makeEmptyTextBlock())
+      }
+      if (!next) {
+        spacedItems.push(makeEmptyTextBlock())
+      }
+    }
+  }
   if (spacedItems.length === 0) {
     spacedItems.push(makeEmptyTextBlock())
   }

--- a/src/ed.js
+++ b/src/ed.js
@@ -109,6 +109,8 @@ export default class Ed {
     }
     this.editableView = editableView
     this.pm = editableView.pm
+
+    this.pm.focus()
   }
   _initializeContent (content) {
     for (let i = 0, len = content.length; i < len; i++) {

--- a/test/convert/grid-to-doc.js
+++ b/test/convert/grid-to-doc.js
@@ -18,7 +18,8 @@ describe('GridToDoc', function () {
     const expected =
       { 'type': 'doc'
       , 'content':
-        [ { 'type': 'media'
+        [ { 'type': 'paragraph' }
+        , { 'type': 'media'
           , 'attrs':
             { 'id': 'image-0000'
             , 'type': 'image'
@@ -56,6 +57,7 @@ describe('GridToDoc', function () {
             , 'height': 50
             }
           }
+        , { 'type': 'paragraph' }
         ]
       }
 
@@ -75,6 +77,7 @@ describe('GridToDoc', function () {
       , 'content':
         [ { 'type': 'paragraph' }
         , { 'type': 'horizontal_rule' }
+        , { 'type': 'paragraph' }
         , { 'type': 'media'
           , 'attrs':
             { 'id': 'image-0000'
@@ -82,17 +85,19 @@ describe('GridToDoc', function () {
             , 'height': 50
             }
           }
-        , { 'type': 'media'
+         , { 'type': 'paragraph' }
+         , { 'type': 'media'
           , 'attrs':
             { 'id': 'video-0000'
             , 'type': 'video'
             , 'height': 50
             }
           }
+        , { 'type': 'paragraph' }
         ]
       }
 
-    it('spaces with empty paragraph', function () {
+    it('spaces with empty paragraphs', function () {
       const doc = GridToDoc(fixture)
       expect(doc.toJSON()).to.deep.equal(expected)
     })

--- a/test/plugins/widget.js
+++ b/test/plugins/widget.js
@@ -11,6 +11,7 @@ describe('PluginWidget', function () {
       , type: 'placeholder'
       , metadata: {status: 'Status', starred: true}
       }
+    , {type: 'text', html: '<p>Text</p>', metadata: {starred: true}}
     , { id: '0000'
       , type: 'placeholder'
       , metadata: {status: 'Status', starred: true}
@@ -40,19 +41,21 @@ describe('PluginWidget', function () {
   describe('Content mounting and merging', function () {
     it('has expected pm document', function () {
       const content = ed.pm.doc.content.content
-      expect(content.length).to.equal(4)
+      expect(content.length).to.equal(5)
       expect(content[0].textContent).to.equal('Title')
       expect(content[0].type.name).to.equal('heading')
       expect(content[1].textContent).to.equal('')
       expect(content[1].type.name).to.equal('media')
       expect(content[1].attrs.id).to.equal('0001')
       expect(content[1].attrs.type).to.equal('placeholder')
-      expect(content[2].textContent).to.equal('')
-      expect(content[2].type.name).to.equal('media')
-      expect(content[2].attrs.id).to.equal('0000')
-      expect(content[2].attrs.type).to.equal('placeholder')
-      expect(content[3].textContent).to.equal('Text')
-      expect(content[3].type.name).to.equal('paragraph')
+      expect(content[2].textContent).to.equal('Text')
+      expect(content[2].type.name).to.equal('paragraph')
+      expect(content[3].textContent).to.equal('')
+      expect(content[3].type.name).to.equal('media')
+      expect(content[3].attrs.id).to.equal('0000')
+      expect(content[3].attrs.type).to.equal('placeholder')
+      expect(content[4].textContent).to.equal('Text')
+      expect(content[4].type.name).to.equal('paragraph')
     })
 
     it('has mounted widget', function () {
@@ -138,10 +141,10 @@ describe('PluginWidget', function () {
 
       // PM placeholder change is sync
       const content = ed.pm.doc.content.content
-      expect(content[2].textContent).to.equal('')
-      expect(content[2].type.name).to.equal('media')
-      expect(content[2].attrs.id).to.equal('0000')
-      expect(content[2].attrs.type).to.equal('image')
+      expect(content[3].textContent).to.equal('')
+      expect(content[3].type.name).to.equal('media')
+      expect(content[3].attrs.id).to.equal('0000')
+      expect(content[3].attrs.type).to.equal('image')
     })
   })
 })


### PR DESCRIPTION
These should help with #211 
- Space media with blank `p`: easier focus on mobile
- Skip empty blocks with `getContent`
- Focus on load
