### PR TITLE
coverPrefs, unsalvageable, caption

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 ## dev
 
+## 0.13.1 - 2016-05-31
+
+* "Image" menu on blocks
+  * "Upload New Image" button moved here
+  * `metadata.coverPrefs` checkboxen (#199)
+  * Image hover title editing
+* Image caption editing (#213)
+* Message and upload button for `cover.unsalvageable` (#195)
+
 ## 0.13.0 - 2016-05-30
 
 * FIX -- Upload Image Button disappears after cancel upload (#219)

--- a/demo/fixture.js
+++ b/demo/fixture.js
@@ -598,7 +598,7 @@ let post = {
     },
     {
       'type': 'text',
-      'html': '<p>Here\'s an article block with failed upload:</p>',
+      'html': '<p>Here\'s an article block with <b>failed</b> upload:</p>',
       'metadata': {'starred': true}
     },
     {
@@ -606,6 +606,18 @@ let post = {
       'type': 'article',
       'html': '<article><h1>boo</h1></article>',
       'metadata': {starred: true, title: 'boo', description: '', progress: 33, failed: true}
+    },
+    {
+      'type': 'text',
+      'html': '<p>Here\'s an image block with <b>unsalvageable</b> cover:</p>',
+      'metadata': {'starred': true}
+    },
+    {
+      'id': '0000-image-unsalvageable',
+      'type': 'image',
+      'html': '',
+      'metadata': {starred: true, caption: 'Sometimes images go away :-('},
+      'cover': {unsalvageable: true}
     },
     {
       'id': 'abc-00000000-h1',

--- a/src/components/attribution-editor.js
+++ b/src/components/attribution-editor.js
@@ -182,6 +182,9 @@ function renderFields (schema, metadata = {}, onChange) {
   if (schema.description) {
     fields.push(renderTextField('description', 'DESCRIPTION', metadata.description, onChange))
   }
+  if (schema.caption) {
+    fields.push(renderTextField('caption', 'CAPTION', metadata.caption, onChange))
+  }
   return fields
 }
 

--- a/src/components/attribution-editor.js
+++ b/src/components/attribution-editor.js
@@ -241,7 +241,7 @@ function renderMenus (schema, metadata = {}, onChange, onMoreClick) {
   }
   if (schema.author && metadata.author && metadata.author[0]) {
     menus.push(
-      renderCreditEditor(false, 'author.0', 'Author', metadata.author[0], onChange, ['author', 0])
+      renderCreditEditor(false, 'author.0', 'Credit', metadata.author[0], onChange, ['author', 0])
     )
   }
   if (schema.publisher && metadata.publisher) {

--- a/src/components/attribution-editor.js
+++ b/src/components/attribution-editor.js
@@ -11,6 +11,7 @@ import Space from 'rebass/dist/Space'
 import Image from './image'
 import DropdownGroup from './dropdown-group'
 import CreditEditor from './credit-editor'
+import ImageEditor from './image-editor'
 import CreditAdd from './credit-add'
 import TextareaAutosize from './textarea-autosize'
 
@@ -32,7 +33,7 @@ class AttributionEditor extends React.Component {
     const {type, metadata} = block
     const schema = blockMetaSchema[type] || blockMetaSchema.default
 
-    const menus = renderMenus(schema, metadata, this.onChange.bind(this), this.onMoreClick.bind(this))
+    const menus = renderMenus(type, schema, metadata, this.onChange.bind(this), this.onMoreClick.bind(this), this.onUploadRequest.bind(this))
 
     return el(
       'div'
@@ -115,7 +116,7 @@ class AttributionEditor extends React.Component {
     , 'We were unable to find the image originally saved with this block.'
     , el(Space, {auto: true})
     , el(Button
-      , { onClick: () => this.onMoreClick('changeCover')
+      , { onClick: () => this.onUploadRequest()
         , rounded: true
         , color: 'error'
         , backgroundColor: 'white'
@@ -137,6 +138,11 @@ class AttributionEditor extends React.Component {
       , theme
       }
     )
+  }
+  onUploadRequest () {
+    const {store} = this.context
+    const {id} = this.props
+    store.routeChange('MEDIA_BLOCK_REQUEST_COVER_UPLOAD', id)
   }
   onChange (path, value) {
     const {store} = this.context
@@ -172,9 +178,6 @@ class AttributionEditor extends React.Component {
         path = [key]
         value = {}
         block = store.routeChange('MEDIA_BLOCK_UPDATE_META', {id, path, value})
-        break
-      case 'changeCover':
-        store.routeChange('MEDIA_BLOCK_REQUEST_COVER_UPLOAD', id)
         break
       default:
         return
@@ -232,7 +235,7 @@ function renderTextField (key, label, value, onChange) {
   )
 }
 
-function renderMenus (schema, metadata = {}, onChange, onMoreClick) {
+function renderMenus (type, schema, metadata = {}, onChange, onMoreClick, onUploadRequest) {
   let menus = []
   if (schema.isBasedOnUrl && metadata.isBasedOnUrl != null) {
     menus.push(
@@ -248,6 +251,9 @@ function renderMenus (schema, metadata = {}, onChange, onMoreClick) {
     menus.push(
       renderCreditEditor(false, 'publisher', 'Publisher', metadata.publisher, onChange, ['publisher'])
     )
+  }
+  if (schema.changeCover) {
+    menus.push(renderImageEditor(type, metadata.title, metadata.coverPrefs, onChange, onUploadRequest))
   }
   menus.push(
     el(CreditAdd
@@ -272,6 +278,21 @@ function renderCreditEditor (onlyUrl, key, label, item, onChange, path) {
     , path: path || [key]
     , onChange
     , onlyUrl
+    }
+  )
+}
+
+function renderImageEditor (type, title, coverPrefs = {}, onChange, onUploadRequest) {
+  const {filter, crop, overlay} = coverPrefs
+  return el(ImageEditor
+  , { title
+    , filter
+    , crop
+    , overlay
+    , onChange
+    , onUploadRequest
+    , type
+    , name: 'Image'
     }
   )
 }

--- a/src/components/attribution-editor.js
+++ b/src/components/attribution-editor.js
@@ -2,12 +2,18 @@
 require('./attribution-editor.css')
 
 import React, {createElement as el} from 'react'
+
+import Progress from 'rebass/dist/Progress'
+import Message from 'rebass/dist/Message'
+import Button from 'rebass/dist/Button'
+import Space from 'rebass/dist/Space'
+
 import Image from './image'
 import DropdownGroup from './dropdown-group'
 import CreditEditor from './credit-editor'
 import CreditAdd from './credit-add'
 import TextareaAutosize from './textarea-autosize'
-import Progress from 'rebass/dist/Progress'
+
 import blockMetaSchema from '../schema/block-meta'
 
 
@@ -32,6 +38,7 @@ class AttributionEditor extends React.Component {
       'div'
       , { className: 'AttributionEditor' }
       , this.renderCover()
+      , this.renderUnsalvageable()
       , this.renderProgress()
       , el('div'
         , { className: 'AttributionEditor-metadata'
@@ -90,6 +97,24 @@ class AttributionEditor extends React.Component {
         }
       }
     , el(Image, props)
+    )
+  }
+  renderUnsalvageable () {
+    const {block} = this.state
+    if (!block || !block.cover || !block.cover.unsalvageable) return
+
+    return el(Message
+    , {theme: 'error'}
+    , 'We were unable to find the image originally saved with this block.'
+    , el(Space, {auto: true})
+    , el(Button
+      , { onClick: () => this.onMoreClick('changeCover')
+        , rounded: true
+        , color: 'error'
+        , backgroundColor: 'white'
+        }
+      , 'Upload New Image'
+      )
     )
   }
   renderProgress () {

--- a/src/components/attribution-editor.js
+++ b/src/components/attribution-editor.js
@@ -71,6 +71,13 @@ class AttributionEditor extends React.Component {
       )
     )
   }
+  canChangeCover () {
+    const {block} = this.state
+    if (!block) return false
+    const {type} = block
+    const schema = blockMetaSchema[type] || blockMetaSchema.default
+    return schema.changeCover
+  }
   renderCover () {
     const {block} = this.state
     if (!block) return
@@ -101,7 +108,7 @@ class AttributionEditor extends React.Component {
   }
   renderUnsalvageable () {
     const {block} = this.state
-    if (!block || !block.cover || !block.cover.unsalvageable) return
+    if (!block || !block.cover || !block.cover.unsalvageable || !this.canChangeCover()) return
 
     return el(Message
     , {theme: 'error'}

--- a/src/components/credit-add.js
+++ b/src/components/credit-add.js
@@ -25,9 +25,6 @@ function makeLinks (schema, metadata = {}, onClick) {
   if (schema.publisher && !metadata.publisher) {
     links.push(makeLink('publisher', 'Add Publisher', onClick))
   }
-  if (schema.changeCover) {
-    links.push(makeLink('changeCover', 'Upload New Image', onClick))
-  }
   links.push(makeLink('delete', 'Remove Block', onClick, true))
   return links
 }

--- a/src/components/credit-add.js
+++ b/src/components/credit-add.js
@@ -20,7 +20,7 @@ function makeLinks (schema, metadata = {}, onClick) {
   }
   // TODO allow multiple authors?
   if (schema.author && (!metadata.author || !metadata.author[0])) {
-    links.push(makeLink('author', 'Add Author', onClick))
+    links.push(makeLink('author', 'Add Credit', onClick))
   }
   if (schema.publisher && !metadata.publisher) {
     links.push(makeLink('publisher', 'Add Publisher', onClick))

--- a/src/components/image-editor.js
+++ b/src/components/image-editor.js
@@ -1,0 +1,72 @@
+import {createElement as el} from 'react'
+
+import TextareaAutosize from './textarea-autosize'
+import Checkbox from 'rebass/dist/Checkbox'
+import ButtonOutline from 'rebass/dist/ButtonOutline'
+
+
+export default function ImageEditor (props, context) {
+  const {title, filter, crop, overlay, type, onChange, onUploadRequest} = props
+
+  return el('div'
+  , { style:
+      { padding: '1rem'
+      , minWidth: 360
+      }
+    }
+  , renderTextFields(type, title, onChange)
+  , renderToggle('filter', 'Allow filters', filter, onChange, ['coverPrefs', 'filter'])
+  , renderToggle('crop', 'Allow cropping', crop, onChange, ['coverPrefs', 'crop'])
+  , renderToggle('overlay', 'Allow overlay', overlay, onChange, ['coverPrefs', 'overlay'])
+  , renderUploadButton(onUploadRequest)
+  )
+}
+
+function renderTextFields (type, title, onChange) {
+  if (type !== 'image') return
+  return renderTextField('title', 'Image Hover Title', title, onChange, ['title'], true, '')
+  // TODO alt text: depends on API
+  // html-flatten expects caption to be saved in html alt
+}
+
+function renderTextField (key, label, value, onChange, path, defaultFocus, placeholder) {
+  return el(TextareaAutosize
+  , { className: `ImageEditor-${key}`
+    , label
+    , defaultValue: value
+    , defaultFocus
+    , key: key
+    , name: key
+    , multiLine: true
+    , style: {width: '100%'}
+    , onChange: makeChange(path, onChange)
+    , placeholder
+    }
+  )
+}
+
+function renderToggle (key, label, value, onChange, path) {
+  return el(Checkbox
+  , { key
+    , label
+    , name: key
+    , checked: (value !== false)
+    , onChange: makeChange(path, onChange, true)}
+  )
+}
+
+function makeChange (path, onChange, checked = false) {
+  return function (event) {
+    const value = (checked ? event.target.checked : event.target.value)
+    onChange(path, value)
+  }
+}
+
+function renderUploadButton (onClick) {
+  return el(ButtonOutline
+  , { onClick
+    , theme: 'warning'
+    }
+  , 'Upload New Image'
+  )
+}

--- a/src/ed.js
+++ b/src/ed.js
@@ -168,7 +168,11 @@ export default class Ed {
     // MUTATION
     let parent = block.metadata
     for (let i = 0, length = path.length; i < length - 1; i++) {
-      parent = parent[path[i]]
+      const key = path[i]
+      if (!parent[key]) {
+        parent[key] = {}
+      }
+      parent = parent[key]
     }
     parent[path[path.length - 1]] = value
 

--- a/src/schema/block-meta.js
+++ b/src/schema/block-meta.js
@@ -3,8 +3,9 @@ import encode from '../util/encode'
 
 const blockMetaSchema =
   { image:
-    { title: true
-    , description: true
+    { title: false
+    , description: false
+    , caption: true
     , isBasedOnUrl: true
     , cover: true
     , changeCover: true
@@ -15,6 +16,7 @@ const blockMetaSchema =
   , video:
     { title: true
     , description: true
+    , caption: false
     , isBasedOnUrl: true
     , cover: true
     , changeCover: false
@@ -24,6 +26,7 @@ const blockMetaSchema =
   , article:
     { title: true
     , description: true
+    , caption: false
     , isBasedOnUrl: true
     , cover: true
     , changeCover: true
@@ -34,6 +37,7 @@ const blockMetaSchema =
   , quote:
     { title: false
     , description: false
+    , caption: false
     , isBasedOnUrl: true
     , cover: false
     , changeCover: false
@@ -43,6 +47,7 @@ const blockMetaSchema =
   , default:
     { title: true
     , description: true
+    , caption: false
     , isBasedOnUrl: true
     , cover: true
     , changeCover: false
@@ -59,8 +64,8 @@ function makeImage (metadata, cover) {
   if (metadata && metadata.title) {
     htmlString += ` title="${encode(metadata.title)}"`
   }
-  if (metadata && metadata.description) {
-    htmlString += ` alt="${encode(metadata.description)}"`
+  if (metadata && metadata.caption) {
+    htmlString += ` alt="${encode(metadata.caption)}"`
   }
   htmlString += '>'
   return htmlString

--- a/src/schema/ed-schema-full.js
+++ b/src/schema/ed-schema-full.js
@@ -18,7 +18,7 @@ class EdHeading extends Heading {
 
 const EdSchema = new Schema(
   { nodes:
-    { doc: {type: Doc, content: '(paragraph | topblock | ordered_list | bullet_list)+'}
+    { doc: {type: Doc, content: '(block | topblock)+'}
     , paragraph: {type: Paragraph, content: 'inline<_>*', group: 'block'}
     , blockquote: {type: BlockQuote, content: 'block+', group: 'topblock'}
     , ordered_list: {type: OrderedList, content: 'list_item+', group: 'block'}

--- a/test/schema/block-meta.js
+++ b/test/schema/block-meta.js
@@ -17,7 +17,7 @@ describe('BlockMeta', function () {
       { type: 'image'
       , metadata:
         { title: 'Title'
-        , description: 'Description yö'
+        , caption: 'Description yö'
         }
       , cover:
         { src: 'http://....jpg'


### PR DESCRIPTION
- "Image" menu on blocks
  - "Upload New Image" button moved here
  - `metadata.coverPrefs` checkboxen (#199)
  - Image hover title editing
- Image caption editing (#213)
- Message and upload button for `cover.unsalvageable` (#195)
- "Add Author" changed to "Add Credit"
