### PR TITLE
attribution via; open urls; remove attr; style

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,13 @@
 ## dev
 
+## 0.13.2 - 2016-06-02
+
 * Render image with hover `title`
 * Attribution `via` can be added and edited (#114)
+* Open urls in new tab (#130)
+* Placeholder cancel button style tweak (#218)
+* Media / attribution style tweak, put image back in box (#226)
+* Remove attribution (#225)
 
 ## 0.13.1 - 2016-05-31
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## dev
 
+* Render image with hover `title`
 ## 0.13.1 - 2016-05-31
 
 * "Image" menu on blocks

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 ## dev
 
 * Render image with hover `title`
+* Attribution `via` can be added and edited (#114)
+
 ## 0.13.1 - 2016-05-31
 
 * "Image" menu on blocks

--- a/demo/fixture.js
+++ b/demo/fixture.js
@@ -620,6 +620,18 @@ let post = {
       'cover': {unsalvageable: true}
     },
     {
+      'type': 'text',
+      'html': '<p>Placeholder with preview:</p>',
+      'metadata': {'starred': true}
+    },
+    {
+      'id': '0000-placeholder-preview',
+      'type': 'placeholder',
+      'html': '',
+      'metadata': {starred: true, status: 'Uploading...', progress: 85},
+      'cover': {src: 'https://pbs.twimg.com/profile_images/674936695830282240/np255F6b_400x400.jpg'}
+    },
+    {
       'id': 'abc-00000000-h1',
       'type': 'h1',
       'html': `<h1>${getHappyLittlePhrase()}</h1>`,

--- a/src/components/app.css
+++ b/src/components/app.css
@@ -4,7 +4,8 @@
 }
 
 @media screen and (max-width: 768px) {
-  .Ed button {
+  .Ed .AddCover button,
+  .Ed .AddFold button {
     width: 100% !important;
   }
 

--- a/src/components/app.css
+++ b/src/components/app.css
@@ -3,22 +3,19 @@
   line-height: 1.5;
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 500px) {
   .Ed .AddCover button,
   .Ed .AddFold button {
     width: 100% !important;
   }
 
-  .Ed .Ed-Divider {
-    margin: 80px 0;
-  }
-
   .Ed .Menu {
     width: 100%;
   }
-
+  
+  .Ed .DropdownGroup > button,
   .Ed .NavItem {
-    font-size: 1.2em !important;
-    padding: 15px 20px !important;
+    font-size: 1rem !important;
+    padding: 10px !important;
   }
 }

--- a/src/components/attribution-editor.css
+++ b/src/components/attribution-editor.css
@@ -32,4 +32,7 @@
   .AttributionEditor-metadata {
     padding: 2em 3em 0 !important;
   }
+  .AttributionEditor button {
+    width: 100% !important;
+  }
 }

--- a/src/components/attribution-editor.css
+++ b/src/components/attribution-editor.css
@@ -2,7 +2,7 @@
 }
 
 .AttributionEditor-title textarea {
-  font-size: 32px !important;
+  font-size: 48px !important;
   margin-top: 0 !important;
   line-height: 1.2;
 }
@@ -21,16 +21,9 @@
   opacity: 1 !important;
 }
 
-.AttributionEditor-metadata {
-  padding: 1em !important;
-}
-
-@media screen and (min-width: 728px){
+@media screen and (max-width: 500px){
   .AttributionEditor-title textarea {
-    font-size: 48px !important;
-  }
-  .AttributionEditor-metadata {
-    padding: 2em 3em 0 !important;
+    font-size: 32px !important;
   }
   .AttributionEditor button {
     width: 100% !important;

--- a/src/components/attribution-editor.js
+++ b/src/components/attribution-editor.js
@@ -37,29 +37,28 @@ class AttributionEditor extends React.Component {
 
     return el(
       'div'
-      , { className: 'AttributionEditor' }
+      , { className: 'AttributionEditor' 
+        , style:
+          { padding: '1rem 1rem 0'
+          , background: '#fff'
+          , border: '1px solid #ddd'
+          , borderRadius: 2
+          }
+        }
       , this.renderCover()
       , this.renderUnsalvageable()
       , this.renderProgress()
       , el('div'
         , { className: 'AttributionEditor-metadata'
           , style:
-            { width: '90%'
-            , margin: '0 auto 36px'
-            , padding: '1.5em 3em 0'
-            , background: '#fff'
-            , border: '1px solid #ddd'
-            , opacity: '.96'
-            , transition: '.1s all ease-out'
-            , position: 'relative'
-            , borderRadius: 2
+            { position: 'relative'
             }
           }
         , renderFields(schema, metadata, this.onChange.bind(this))
         , el('div'
           , { className: 'AttributionEditor-links'
             , style:
-              { margin: '2em -3em 0'
+              { margin: '1em -1em 0'
               , position: 'relative'
               , top: 1
               }
@@ -105,6 +104,7 @@ class AttributionEditor extends React.Component {
       , style:
         { width: '100%'
         , position: 'relative'
+        , marginBottom: '1rem'
         }
       }
     , el(Image, props)

--- a/src/components/attribution-editor.js
+++ b/src/components/attribution-editor.js
@@ -82,21 +82,24 @@ class AttributionEditor extends React.Component {
   renderCover () {
     const {block} = this.state
     if (!block) return
-    const {id, cover} = block
+    const {id, cover, metadata} = block
     const {store} = this.context
     const preview = store.getCoverPreview(id)
     if (!cover && !preview) return
-    let src, width, height
+    let src, width, height, title
     if (cover) {
       src = cover.src
       width = cover.width
       height = cover.height
     }
+    if (metadata) {
+      title = metadata.title
+    }
     if (preview) {
       src = preview
     }
     if (!src) return
-    let props = {src, width, height}
+    let props = {src, width, height, title}
     return el('div'
     , { className: 'AttributionEditor-cover'
       , style:

--- a/src/components/attribution-editor.js
+++ b/src/components/attribution-editor.js
@@ -37,7 +37,7 @@ class AttributionEditor extends React.Component {
 
     return el(
       'div'
-      , { className: 'AttributionEditor' 
+      , { className: 'AttributionEditor'
         , style:
           { padding: '1rem 1rem 0'
           , background: '#fff'

--- a/src/components/attribution-editor.js
+++ b/src/components/attribution-editor.js
@@ -35,8 +35,7 @@ class AttributionEditor extends React.Component {
 
     const menus = renderMenus(type, schema, metadata, this.onChange.bind(this), this.onMoreClick.bind(this), this.onUploadRequest.bind(this))
 
-    return el(
-      'div'
+    return el('div'
       , { className: 'AttributionEditor'
         , style:
           { padding: '1rem 1rem 0'

--- a/src/components/attribution-editor.js
+++ b/src/components/attribution-editor.js
@@ -167,18 +167,23 @@ class AttributionEditor extends React.Component {
         store.routeChange('MEDIA_BLOCK_REMOVE', id)
         return
       case 'isBasedOnUrl':
-        path = [key]
+        path = ['isBasedOnUrl']
         value = ''
         block = store.routeChange('MEDIA_BLOCK_UPDATE_META', {id, path, value})
         break
       case 'author':
-        path = [key]
+        path = ['author']
         // TODO smarter when we support multiple
         value = [{}]
         block = store.routeChange('MEDIA_BLOCK_UPDATE_META', {id, path, value})
         break
+      case 'via':
+        path = ['via']
+        value = {}
+        block = store.routeChange('MEDIA_BLOCK_UPDATE_META', {id, path, value})
+        break
       case 'publisher':
-        path = [key]
+        path = ['publisher']
         value = {}
         block = store.routeChange('MEDIA_BLOCK_UPDATE_META', {id, path, value})
         break
@@ -245,9 +250,15 @@ function renderMenus (type, schema, metadata = {}, onChange, onMoreClick, onUplo
       renderCreditEditor(true, 'isBasedOnUrl', 'Link', {url: metadata.isBasedOnUrl}, onChange, ['isBasedOnUrl'])
     )
   }
+  // TODO support >1 author
   if (schema.author && metadata.author && metadata.author[0]) {
     menus.push(
       renderCreditEditor(false, 'author.0', 'Credit', metadata.author[0], onChange, ['author', 0])
+    )
+  }
+  if (schema.via && metadata.via) {
+    menus.push(
+      renderCreditEditor(false, 'via', 'Via', metadata.via, onChange, ['via'])
     )
   }
   if (schema.publisher && metadata.publisher) {
@@ -296,6 +307,7 @@ function renderImageEditor (type, title, coverPrefs = {}, onChange, onUploadRequ
     , onUploadRequest
     , type
     , name: 'Image'
+    , label: 'Image'
     }
   )
 }

--- a/src/components/credit-add.js
+++ b/src/components/credit-add.js
@@ -22,6 +22,9 @@ function makeLinks (schema, metadata = {}, onClick) {
   if (schema.author && (!metadata.author || !metadata.author[0])) {
     links.push(makeLink('author', 'Add Credit', onClick))
   }
+  if (schema.via && !metadata.via) {
+    links.push(makeLink('via', 'Add Via', onClick))
+  }
   if (schema.publisher && !metadata.publisher) {
     links.push(makeLink('publisher', 'Add Publisher', onClick))
   }

--- a/src/components/credit-editor.js
+++ b/src/components/credit-editor.js
@@ -5,6 +5,7 @@ import TextareaAutosize from './textarea-autosize'
 import {isUrl} from '../util/url'
 
 import Avatar from 'rebass/dist/Avatar'
+import ButtonOutline from 'rebass/dist/ButtonOutline'
 
 function isUrlOrBlank (string) {
   return (isUrl(string) || string === '')
@@ -16,7 +17,7 @@ export default function CreditEditor (props, context) {
 
   return el('div'
   , { style:
-      { padding: '1rem 1rem 0 1rem'
+      { padding: '1rem'
       , minWidth: 360
       }
     }
@@ -26,6 +27,7 @@ export default function CreditEditor (props, context) {
     ? renderBasedOnUrl(url, onChange, path)
     : renderFields(name, url, avatar, onChange, path)
     )
+  , renderRemove(onChange, path)
   )
 }
 CreditEditor.contextTypes = {imgfloConfig: React.PropTypes.object}
@@ -46,6 +48,17 @@ function renderAvatar (avatar, imgfloConfig) {
     , style: {float: 'right'}
     , src
     }
+  )
+}
+
+function renderRemove (onChange, path) {
+  return el(ButtonOutline
+  , { onClick: makeRemove(onChange, path)
+    , style: {float: 'right'}
+    , theme: 'warning'
+    , title: 'delete attribution from block'
+    }
+  , 'Remove'
   )
 }
 
@@ -78,16 +91,22 @@ function renderTextField (key, label, value, onChange, path, defaultFocus, valid
     , name: key
     , multiLine: true
     , style: {width: '100%'}
-    , onChange: makeChange(path, onChange)
+    , onChange: makeChange(onChange, path)
     , validator
     , placeholder
     }
   )
 }
 
-function makeChange (path, onChange) {
+function makeChange (onChange, path) {
   return function (event) {
     const {value} = event.target
     onChange(path, value)
+  }
+}
+
+function makeRemove (onChange, path) {
+  return function () {
+    onChange(path, undefined)
   }
 }

--- a/src/components/credit-editor.js
+++ b/src/components/credit-editor.js
@@ -21,7 +21,7 @@ export default function CreditEditor (props, context) {
       }
     }
   , renderAvatar(avatar, context.imgfloConfig)
-  , renderLabel(label)
+  , (onlyUrl ? '' : renderLabel(label))
   , (onlyUrl
     ? renderBasedOnUrl(url, onChange, path)
     : renderFields(name, url, avatar, onChange, path)
@@ -65,7 +65,7 @@ function renderFields (name, url, avatar, onChange, path) {
 }
 
 function renderBasedOnUrl (value, onChange, path) {
-  return renderTextField('url', '', value, onChange, path, true, isUrlOrBlank, 'https...')
+  return renderTextField('url', 'Link', value, onChange, path, true, isUrlOrBlank, 'https...')
 }
 
 function renderTextField (key, label, value, onChange, path, defaultFocus, validator, placeholder) {

--- a/src/components/dropdown-group.js
+++ b/src/components/dropdown-group.js
@@ -17,7 +17,7 @@ class DropdownGroup extends React.Component {
       return
     }
     // Find and open new menu
-    if (nextProps.menus.length !== this.props.menus.length) {
+    if (nextProps.menus.length > this.props.menus.length) {
       for (let i = 0, len = nextProps.menus.length; i < len; i++) {
         const menu = this.props.menus[i]
         const nextMenu = nextProps.menus[i]
@@ -26,6 +26,10 @@ class DropdownGroup extends React.Component {
           return
         }
       }
+    }
+    // Close if removed
+    if (nextProps.menus.length < this.props.menus.length) {
+      this.setState({openMenu: null})
     }
   }
   componentDidUpdate (_, prevState) {

--- a/src/components/image.js
+++ b/src/components/image.js
@@ -10,7 +10,7 @@ import imgflo from 'imgflo-url'
 
 
 export default function Image (props, context) {
-  let {src} = props
+  let {src, title} = props
   const {width, height} = props
   if (context && context.imgfloConfig) {
     const params =
@@ -20,7 +20,7 @@ export default function Image (props, context) {
     src = imgflo(context.imgfloConfig, 'passthrough', params)
   }
   return el('div', {className: 'Image'}
-    , el('img', {src: src})
+    , el('img', {src, title})
   )
 }
 Image.contextTypes = {

--- a/src/components/textarea-autosize.css
+++ b/src/components/textarea-autosize.css
@@ -1,10 +1,3 @@
-.TextareaAutosize label span{
-  letter-spacing: .1rem;
-  color: #aaa;
-  font-size: 10px;
-  text-transform: uppercase;
-}
-
 .TextareaAutosize textarea {
   font-size: 16px;
 }

--- a/src/components/textarea-autosize.js
+++ b/src/components/textarea-autosize.js
@@ -86,6 +86,7 @@ class TextareaAutosize extends React.Component {
     const {label} = this.props
     if (label !== 'Link') return
     const {value, valid} = this.state
+    if (!value) return
     if (!valid) {
       return el('span', {}, ' - must be a valid url starting with "http"')
     }

--- a/src/components/textarea-autosize.js
+++ b/src/components/textarea-autosize.js
@@ -67,6 +67,7 @@ class TextareaAutosize extends React.Component {
       , { style: (valid ? labelStyle : labelStyleError)
         }
       , label
+      , this.renderLink()
       , el('textarea'
         , { ref: 'textarea'
           , style: areaStyle
@@ -79,6 +80,25 @@ class TextareaAutosize extends React.Component {
           }
         )
       )
+    )
+  }
+  renderLink () {
+    const {label} = this.props
+    if (label !== 'Link') return
+    const {value, valid} = this.state
+    if (!valid) {
+      return el('span', {}, ' - must be a valid url starting with "http"')
+    }
+    return el('a'
+    , { href: value
+      , target: '_blank'
+      , rel: 'noreferrer noopener'
+      , style:
+        { marginLeft: '0.5rem'
+        , textDecoration: 'none'
+        }
+      }
+    , 'open'
     )
   }
   onKeyDown (event) {

--- a/src/ed.js
+++ b/src/ed.js
@@ -165,6 +165,9 @@ export default class Ed {
     if (!block) {
       throw new Error('Can not update this block')
     }
+    if (!path || !path.length) {
+      throw new Error('Invalid metadata update path')
+    }
     // MUTATION
     let parent = block.metadata
     for (let i = 0, length = path.length; i < length - 1; i++) {
@@ -174,7 +177,18 @@ export default class Ed {
       }
       parent = parent[key]
     }
-    parent[path[path.length - 1]] = value
+    const key = path[path.length - 1]
+    parent[key] = value
+
+    if (value === undefined) {
+      if (key === 0) {
+        // HACK only for author array
+        parent.shift()
+      }
+      else {
+        delete parent[key]
+      }
+    }
 
     return block
   }

--- a/src/ed.js
+++ b/src/ed.js
@@ -184,8 +184,7 @@ export default class Ed {
       if (key === 0) {
         // HACK only for author array
         parent.shift()
-      }
-      else {
+      } else {
         delete parent[key]
       }
     }

--- a/src/schema/block-meta.js
+++ b/src/schema/block-meta.js
@@ -11,6 +11,7 @@ const blockMetaSchema =
     , changeCover: true
     , author: true
     , publisher: true
+    , via: true
     , makeHtml: makeImage
     }
   , video:
@@ -22,6 +23,7 @@ const blockMetaSchema =
     , changeCover: false
     , author: true
     , publisher: true
+    , via: true
     }
   , article:
     { title: true
@@ -32,6 +34,7 @@ const blockMetaSchema =
     , changeCover: true
     , author: true
     , publisher: true
+    , via: true
     , makeHtml: makeArticle
     }
   , quote:
@@ -43,6 +46,7 @@ const blockMetaSchema =
     , changeCover: false
     , author: true
     , publisher: true
+    , via: true
     }
   , default:
     { title: true
@@ -53,6 +57,7 @@ const blockMetaSchema =
     , changeCover: false
     , author: true
     , publisher: true
+    , via: true
     }
   }
 


### PR DESCRIPTION
- Render image with hover `title`
- Attribution `via` can be added and edited (#114)
- Open urls in new tab (#130)
- Placeholder cancel button style tweak (#218)
- Media / attribution style tweak, put image back in box (#226)
- Remove attribution (#225)
