### PR TITLE
Feature/add media ui

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## dev
 
+## 0.17.3 - 2016-06-22
+
+* UI in menus add code and location blocks (#245)
+  * `ed_add_code` and `ed_add_location` added to [commands](https://github.com/the-grid/ed#commands)
+
 ## 0.17.2 - 2016-06-21
 
 * Use rsync for `npm run copycss`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * UI in menus add code and location blocks (#245)
   * `ed_add_code` and `ed_add_location` added to [commands](https://github.com/the-grid/ed#commands)
+* Show coverPrefs when there is a cover. Show upload when that's allowed.
 
 ## 0.17.2 - 2016-06-21
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * UI in menus add code and location blocks (#245)
   * `ed_add_code` and `ed_add_location` added to [commands](https://github.com/the-grid/ed#commands)
 * Show coverPrefs when there is a cover. Show upload when that's allowed.
+* `getContent` whitelist cover unsalvageable, so `{id, type, html, metadata, cover: {src, width, height, unsalvageable}}`
 
 ## 0.17.2 - 2016-06-21
 

--- a/README.md
+++ b/README.md
@@ -160,9 +160,11 @@ bullet_list:wrap
 ordered_list:wrap
 blockquote:wrap
 lift
-ed_upload_image
 undo
 redo
+ed_upload_image
+ed_add_code
+ed_add_location
 ```
 
 # dev

--- a/src/components/attribution-editor.js
+++ b/src/components/attribution-editor.js
@@ -37,10 +37,10 @@ class AttributionEditor extends React.Component {
   }
   render () {
     const {block} = this.state
-    const {type, metadata} = block
+    const {type, metadata, cover} = block
     const schema = blockMetaSchema[type] || blockMetaSchema.default
 
-    const menus = renderMenus(type, schema, metadata, this.boundOnChange, this.boundOnMoreClick, this.boundOnUploadRequest)
+    const menus = renderMenus(type, schema, metadata, cover, this.boundOnChange, this.boundOnMoreClick, this.boundOnUploadRequest)
 
     return el('div'
       , { className: 'AttributionEditor'
@@ -270,7 +270,7 @@ function renderTextField (key, label, value, onChange) {
   )
 }
 
-function renderMenus (type, schema, metadata = {}, onChange, onMoreClick, onUploadRequest) {
+function renderMenus (type, schema, metadata = {}, cover, onChange, onMoreClick, onUploadRequest) {
   let menus = []
   if (schema.isBasedOnUrl && metadata.isBasedOnUrl != null) {
     menus.push(
@@ -293,8 +293,12 @@ function renderMenus (type, schema, metadata = {}, onChange, onMoreClick, onUplo
       renderCreditEditor(false, 'publisher', 'Publisher', metadata.publisher, onChange, ['publisher'])
     )
   }
-  if (schema.changeCover) {
-    menus.push(renderImageEditor(type, metadata.title, metadata.coverPrefs, onChange, onUploadRequest))
+  if (cover || schema.changeCover) {
+    const hasCover = (cover != null)
+    const allowCoverChange = schema.changeCover
+    menus.push(
+      renderImageEditor(hasCover, allowCoverChange, type, metadata.title, metadata.coverPrefs, onChange, onUploadRequest)
+    )
   }
   menus.push(
     el(CreditAdd
@@ -323,10 +327,12 @@ function renderCreditEditor (onlyUrl, key, label, item, onChange, path) {
   )
 }
 
-function renderImageEditor (type, title, coverPrefs = {}, onChange, onUploadRequest) {
+function renderImageEditor (hasCover, allowCoverChange, type, title, coverPrefs = {}, onChange, onUploadRequest) {
   const {filter, crop, overlay} = coverPrefs
   return el(ImageEditor
-  , { title
+  , { hasCover
+    , allowCoverChange
+    , title
     , filter
     , crop
     , overlay

--- a/src/components/editable-menu.css
+++ b/src/components/editable-menu.css
@@ -20,14 +20,14 @@
   padding: 0.5rem 4px;
 }
 
-.ProseMirror-menubar .ProseMirror-menuseparator {
+.ProseMirror-menuseparator {
   display: inline-block;
   height: 2rem;
   vertical-align: middle;
   margin: 0 3px;
 }
 
-.ProseMirror-menubar .ProseMirror-menuitem {
+.ProseMirror-menuitem {
   margin-right: 0;
 }
 
@@ -36,7 +36,10 @@
 }
 
 /* Upload Image button */
-
 .EdMenuText {
   cursor: pointer;
+}
+
+.ProseMirror-tooltip .ProseMirror-menuseparator {
+  margin: 0 6px;
 }

--- a/src/components/image-editor.js
+++ b/src/components/image-editor.js
@@ -6,7 +6,26 @@ import ButtonOutline from 'rebass/dist/ButtonOutline'
 
 
 export default function ImageEditor (props, context) {
-  const {title, filter, crop, overlay, type, onChange, onUploadRequest} = props
+  const {hasCover
+    , allowCoverChange
+    , title
+    , filter
+    , crop
+    , overlay
+    , type
+    , onChange
+    , onUploadRequest
+    } = props
+
+  let toggles = null
+  if (hasCover) {
+    toggles = el('div'
+    , {}
+    , renderToggle('filter', 'Allow filters', filter, onChange, ['coverPrefs', 'filter'])
+    , renderToggle('crop', 'Allow cropping', crop, onChange, ['coverPrefs', 'crop'])
+    , renderToggle('overlay', 'Allow overlay', overlay, onChange, ['coverPrefs', 'overlay'])
+    )
+  }
 
   return el('div'
   , { style:
@@ -15,10 +34,8 @@ export default function ImageEditor (props, context) {
       }
     }
   , renderTextFields(type, title, onChange)
-  , renderToggle('filter', 'Allow filters', filter, onChange, ['coverPrefs', 'filter'])
-  , renderToggle('crop', 'Allow cropping', crop, onChange, ['coverPrefs', 'crop'])
-  , renderToggle('overlay', 'Allow overlay', overlay, onChange, ['coverPrefs', 'overlay'])
-  , renderUploadButton(onUploadRequest)
+  , toggles
+  , (allowCoverChange ? renderUploadButton(onUploadRequest) : null)
   )
 }
 

--- a/src/convert/doc-to-grid.js
+++ b/src/convert/doc-to-grid.js
@@ -69,6 +69,7 @@ function trimContent (content) {
       , [ 'src'
         , 'width'
         , 'height'
+        , 'unsalvageable'
         ]
       )
     }

--- a/src/inputrules/input-code.js
+++ b/src/inputrules/input-code.js
@@ -1,30 +1,22 @@
 import {InputRule} from 'prosemirror/dist/inputrules'
-import uuid from 'uuid'
+// import uuid from 'uuid'
+import {focusedIndex} from '../util/pm'
 
 const inputCode =
   new InputRule(/^```$/, '`', function (pm, _, pos) {
-    insertBlock(pm, pos, pm.schema.nodes.media
-    , { id: uuid.v4()
-      , type: 'code'
-      , initialFocus: true
-      }
-    )
+    const index = focusedIndex(pm)
+    if (index == null) return
+    clearNode(pm, pos)
+    pm.ed.routeChange('ADD_MEDIA', {index, type: 'code'})
   })
 
-function insertBlock (pm, pos, type, attrs) {
+function clearNode (pm, pos) {
   const $pos = pm.doc.resolve(pos)
   const start = pos - $pos.parentOffset
-  const nodePos = start - 1
-  const codeNode = type.create(attrs)
+  // Delete the input shortcut text (like ```)
   pm.tr
-    // Delete the input shortcut text (like ```)
     .delete(start, pos)
-    // Insert the block above the current block
-    .insert(nodePos, codeNode)
     .apply()
-
-  // Hide tooltip
-  pm.content.blur()
 }
 
 export default inputCode

--- a/src/inputrules/input-code.js
+++ b/src/inputrules/input-code.js
@@ -1,5 +1,4 @@
 import {InputRule} from 'prosemirror/dist/inputrules'
-// import uuid from 'uuid'
 import {focusedIndex} from '../util/pm'
 
 const inputCode =

--- a/src/menu/ed-menu.js
+++ b/src/menu/ed-menu.js
@@ -1,7 +1,15 @@
-import {Dropdown, undoItem, redoItem, liftItem} from 'prosemirror/dist/menu/menu'
-import {buildMenuItems} from 'prosemirror/dist/example-setup'
+import { Dropdown
+  , undoItem
+  , redoItem
+  , liftItem
+  } from 'prosemirror/dist/menu/menu'
+import { buildMenuItems } from 'prosemirror/dist/example-setup'
 import EdSchema from '../schema/ed-schema-full'
 import menuImage from './menu-image'
+import { menuMedia
+  , menuCode
+  , menuLocation
+  } from './menu-media'
 
 const menuItems = buildMenuItems(EdSchema)
 const { makeParagraph
@@ -28,9 +36,11 @@ export const edCommands =
   , 'ordered_list:wrap': wrapOrderedList
   , 'blockquote:wrap': wrapBlockQuote
   , 'lift': liftItem
-  , 'ed_upload_image': menuImage
   , 'undo': undoItem
   , 'redo': redoItem
+  , 'ed_upload_image': menuImage
+  , 'ed_add_code': menuCode
+  , 'ed_add_location': menuLocation
   }
 
 const typeDropdown = new Dropdown(
@@ -50,6 +60,7 @@ export const edBlockMenu =
     , liftItem
     ]
   , [ menuImage ]
+  , [ menuMedia ]
   ]
 
 export const edInlineMenu =

--- a/src/menu/menu-media.js
+++ b/src/menu/menu-media.js
@@ -1,0 +1,33 @@
+import {MenuItem, Dropdown} from 'prosemirror/dist/menu/menu'
+import {focusedIndex, isCollapsed} from '../util/pm'
+
+function select (pm) {
+  return isCollapsed(pm)
+}
+
+function makeMenu (type, label) {
+  function run (pm) {
+    const index = focusedIndex(pm)
+    if (index == null) return
+    pm.ed.routeChange('ADD_MEDIA', {index, type})
+  }
+
+  return new MenuItem(
+    { label
+    , title: `make new ${type} block`
+    , run
+    , select
+    }
+  )
+}
+
+export const menuCode = makeMenu('code', 'Code')
+
+export const menuLocation = makeMenu('location', 'Map')
+
+export const menuMedia = new Dropdown(
+  [ menuCode
+  , menuLocation
+  ]
+  , {label: 'Add...'}
+)


### PR DESCRIPTION
- UI in menus add code and location blocks
  - `ed_add_code` and `ed_add_location` added to [commands](https://github.com/the-grid/ed#commands)
- Show coverPrefs when there is a cover. Show upload when that's allowed.
- `getContent` whitelist cover unsalvageable, so `{id, type, html, metadata, cover: {src, width, height, unsalvageable}}`
