### PR TITLE
meta tweaks, drop zone

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 * NEW -- Images can be removed from `article` blocks (#243)
 * Less-chunky metadata editing on small screens (#236)
+* Disable menu on media block selection
 
 ## 0.17.3 - 2016-06-22
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,11 @@
 ## dev
 
+## 0.17.4 - 2016-06-23
+
 * NEW -- Images can be removed from `article` blocks (#243)
 * Less-chunky metadata editing on small screens (#236)
-* Disable menu on media block selection
+* Disable ProseMirror format menu on media block selection
+* Indicator to drop file on block (#235)
 
 ## 0.17.3 - 2016-06-22
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## dev
 
+* Images can be removed from `article` blocks (#243)
+
 ## 0.17.3 - 2016-06-22
 
 * UI in menus add code and location blocks (#245)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## dev
 
-* Images can be removed from `article` blocks (#243)
+* NEW -- Images can be removed from `article` blocks (#243)
+* Less-chunky metadata editing on small screens (#236)
 
 ## 0.17.3 - 2016-06-22
 

--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",
-    "babel-core": "^6.9.1",
-    "babel-eslint": "^6.0.5",
+    "babel-core": "^6.10.4",
+    "babel-eslint": "^6.1.0",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.9.0",
     "bob-ross-lipsum": "^1.1.1",

--- a/src/components/app.css
+++ b/src/components/app.css
@@ -8,14 +8,4 @@
   .Ed .AddFold button {
     width: 100% !important;
   }
-
-  .Ed .Menu {
-    width: 100%;
-  }
-  
-  .Ed .DropdownGroup > button,
-  .Ed .NavItem {
-    font-size: 1rem !important;
-    padding: 10px !important;
-  }
 }

--- a/src/components/attribution-editor.css
+++ b/src/components/attribution-editor.css
@@ -1,8 +1,5 @@
-.AttributionEditor {
-}
-
 .AttributionEditor-title textarea {
-  font-size: 48px !important;
+  font-size: 24px !important;
   margin-top: 0 !important;
   line-height: 1.2;
 }
@@ -22,10 +19,7 @@
 }
 
 @media screen and (max-width: 500px){
-  .AttributionEditor-title textarea {
-    font-size: 32px !important;
-  }
-  .AttributionEditor button {
-    width: 100% !important;
+  .AttributionEditor .Menu {
+    width: 100%;
   }
 }

--- a/src/components/button-confirm.js
+++ b/src/components/button-confirm.js
@@ -1,0 +1,34 @@
+import React, {createElement as el} from 'react'
+
+import ButtonOutline from 'rebass/dist/ButtonOutline'
+
+class ButtonConfirm extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {open: false}
+    this.boundOnConfirm = this.onConfirm.bind(this)
+  }
+  render () {
+    const {confirm, label, theme, style, onClick} = this.props
+    const {open} = this.state
+
+    return el(ButtonOutline
+    , { children: (open ? confirm : label)
+      , onClick: (open ? onClick : this.boundOnConfirm)
+      , theme
+      , style
+      }
+    )
+  }
+  onConfirm () {
+    this.setState({open: true})
+  }
+}
+ButtonConfirm.propTypes =
+  { confirm: React.PropTypes.string.isRequired
+  , label: React.PropTypes.string.isRequired
+  , theme: React.PropTypes.string
+  , style: React.PropTypes.object
+  , onClick: React.PropTypes.func.isRequired
+  }
+export default React.createFactory(ButtonConfirm)

--- a/src/components/image-editor.js
+++ b/src/components/image-editor.js
@@ -8,6 +8,7 @@ import ButtonOutline from 'rebass/dist/ButtonOutline'
 export default function ImageEditor (props, context) {
   const {hasCover
     , allowCoverChange
+    , allowCoverRemove
     , title
     , filter
     , crop
@@ -15,6 +16,7 @@ export default function ImageEditor (props, context) {
     , type
     , onChange
     , onUploadRequest
+    , onCoverRemove
     } = props
 
   let toggles = null
@@ -36,6 +38,7 @@ export default function ImageEditor (props, context) {
   , renderTextFields(type, title, onChange)
   , toggles
   , (allowCoverChange ? renderUploadButton(onUploadRequest) : null)
+  , (allowCoverRemove ? renderRemoveButton(onCoverRemove) : null)
   )
 }
 
@@ -83,7 +86,21 @@ function renderUploadButton (onClick) {
   return el(ButtonOutline
   , { onClick
     , theme: 'warning'
+    , style: { width: '100%' }
     }
   , 'Upload New Image'
+  )
+}
+
+function renderRemoveButton (onClick) {
+  return el(ButtonOutline
+  , { onClick
+    , theme: 'warning'
+    , style:
+      { width: '100%'
+      , marginTop: '0.5rem'
+      }
+    }
+  , 'Remove Image'
   )
 }

--- a/src/components/image-editor.js
+++ b/src/components/image-editor.js
@@ -3,6 +3,7 @@ import {createElement as el} from 'react'
 import TextareaAutosize from './textarea-autosize'
 import Checkbox from 'rebass/dist/Checkbox'
 import ButtonOutline from 'rebass/dist/ButtonOutline'
+import ButtonConfirm from './button-confirm'
 
 
 export default function ImageEditor (props, context) {
@@ -93,14 +94,15 @@ function renderUploadButton (onClick) {
 }
 
 function renderRemoveButton (onClick) {
-  return el(ButtonOutline
+  return el(ButtonConfirm
   , { onClick
+    , label: 'Remove Image'
+    , confirm: 'Remove Image: Are you sure?'
     , theme: 'warning'
     , style:
       { width: '100%'
       , marginTop: '0.5rem'
       }
     }
-  , 'Remove Image'
   )
 }

--- a/src/menu/ed-menu.js
+++ b/src/menu/ed-menu.js
@@ -24,6 +24,19 @@ const { makeParagraph
   , toggleStrong
   } = menuItems
 
+// Disable these menus on media block selection
+function enableIsText (pm) {
+  if (pm.selection && pm.selection.node && !pm.selection.node.isTextblock) {
+    return false
+  }
+  return this.run(pm, false)
+}
+makeParagraph.spec.select = enableIsText
+makeHead1.spec.select = enableIsText
+makeHead2.spec.select = enableIsText
+makeHead3.spec.select = enableIsText
+
+
 export const edCommands =
   { 'strong:toggle': toggleStrong
   , 'em:toggle': toggleEm

--- a/src/schema/block-meta.js
+++ b/src/schema/block-meta.js
@@ -9,6 +9,7 @@ const blockMetaSchema =
     , isBasedOnUrl: true
     , cover: true
     , changeCover: true
+    , removeCover: false
     , author: true
     , publisher: true
     , via: true
@@ -21,6 +22,7 @@ const blockMetaSchema =
     , isBasedOnUrl: true
     , cover: true
     , changeCover: false
+    , removeCover: false
     , author: true
     , publisher: true
     , via: true
@@ -32,6 +34,7 @@ const blockMetaSchema =
     , isBasedOnUrl: true
     , cover: true
     , changeCover: true
+    , removeCover: true
     , author: true
     , publisher: true
     , via: true
@@ -44,6 +47,7 @@ const blockMetaSchema =
     , isBasedOnUrl: true
     , cover: false
     , changeCover: false
+    , removeCover: false
     , author: true
     , publisher: true
     , via: true
@@ -55,6 +59,7 @@ const blockMetaSchema =
     , isBasedOnUrl: true
     , cover: true
     , changeCover: false
+    , removeCover: false
     , author: true
     , publisher: true
     , via: true

--- a/src/store/ed-store.js
+++ b/src/store/ed-store.js
@@ -61,6 +61,10 @@ export default class EdStore {
       case 'MEDIA_BLOCK_REQUEST_COVER_UPLOAD':
         this.onRequestCoverUpload(payload)
         break
+      case 'MEDIA_BLOCK_COVER_REMOVE':
+        const noCoverBlock = this._removeCover(payload)
+        this.trigger('change')
+        return noCoverBlock
       case 'MEDIA_BLOCK_DROP_FILE':
         this.onDropFileOnBlock(payload.id, payload.file)
         break
@@ -171,6 +175,21 @@ export default class EdStore {
       }
     }
 
+    return block
+  }
+  _removeCover (id) {
+    let block = this.getBlock(id)
+    if (!block) {
+      throw new Error('Can not find this block id')
+    }
+    const preview = this.getCoverPreview(id)
+    if (preview) {
+      delete this._coverPreviews[id]
+    }
+    if (block.cover) {
+      // MUTATION
+      delete block.cover
+    }
     return block
   }
   _updateMediaBlock (block) {

--- a/src/util/drop.js
+++ b/src/util/drop.js
@@ -1,9 +1,24 @@
-export function isFileEvent (event) {
+export function isDragFileEvent (event) {
   if (!event) return false
   const {dataTransfer} = event
   if (!dataTransfer) return false
-  const {types, files} = dataTransfer
-  if (!types || types[0] !== 'Files') return false
+  const {types} = dataTransfer
+  if (!types) return false
+  for (let i = 0, len = types.length; i < len; i++) {
+    const type = types[i]
+    if (type === 'Files') {
+      return true
+    }
+  }
+  return false
+}
+
+export function isDropFileEvent (event) {
+  if (!event) return false
+  const {dataTransfer} = event
+  if (!dataTransfer) return false
+  const {files} = dataTransfer
+  if (!isDragFileEvent(event)) return false
   if (!files || !files.length) return false
 
   return true


### PR DESCRIPTION
- NEW -- Images can be removed from `article` blocks (#243)
- Less-chunky metadata editing on small screens (#236)
- Disable ProseMirror format menu on media block selection
- Indicator to drop file on block (#235)
