### PR TITLE
updateProgress: don't save to block metadata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,9 @@
 * BREAKING -- `updatePlaceholder` is now `updateProgress`, with same arguments
 * BREAKING -- `{status, progress, failed}` will not be set from initial content or `setContent`: you must call `updateProgress`
 * BREAKING -- `ed.updateProgress` updates internally and does not change content block metadata (#237)
-* `ed.updateProgress(id, {progress: null})` will now remove progress bar
 * Simplifying updates = perf improvements with `updateProgress`
+* `ed.updateProgress(id, {progress: null})` will now remove progress bar
+* `ed.updateProgress(id, {failed: true})` will now show an error message and retry button
 
 ## 0.17.8 - 2016-07-14
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,10 @@
 ## dev
 
-* BREAKING -- `{status, progress, failed}` will not be set from initial content or `setContent`: you must call `updatePlaceholder`
-* BREAKING -- `ed.updatePlaceholder` updates internally and does not change content block metadata (#237)
-* `ed.updatePlaceholder(id, {progress: null})` will now remove progress bar
-* Simplifying updates = perf improvements with `updatePlaceholder`
+* BREAKING -- `updatePlaceholder` is now `updateProgress`, with same arguments
+* BREAKING -- `{status, progress, failed}` will not be set from initial content or `setContent`: you must call `updateProgress`
+* BREAKING -- `ed.updateProgress` updates internally and does not change content block metadata (#237)
+* `ed.updateProgress(id, {progress: null})` will now remove progress bar
+* Simplifying updates = perf improvements with `updateProgress`
 
 ## 0.17.8 - 2016-07-14
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## dev
 
+* BREAKING -- `{status, progress, failed}` will not be set from initial content or `setContent`: you must call `updatePlaceholder`
+* BREAKING -- `ed.updatePlaceholder` updates internally and does not change content block metadata (#237)
+* `ed.updatePlaceholder(id, {progress: null})` will now remove progress bar
+* Simplifying updates = perf improvements with `updatePlaceholder`
+
 ## 0.17.8 - 2016-07-14
 
 * Dismiss meta dropdown by clicking out of menu or focusing editable (#229)

--- a/README.md
+++ b/README.md
@@ -62,20 +62,20 @@ available to use like this:
     onShareFile: function (index) {
       /* App triggers native file picker */
       /* App calls ed.insertPlaceholders(index, count) and gets array of ids back */
-      /* App uploads files and sets status on placeholder blocks with ed.updatePlaceholder */
+      /* App uploads files and sets status on placeholder blocks with ed.updateProgress */
       /* On upload / measurement finishing, app replaces placeholder blocks with ed.setContent */
     },
     // REQUIRED
     onRequestCoverUpload: function (id) {
       /* Similar to onShareFile, but hit with block id instead of index */
-      /* App uploads files and sets status on blocks with ed.updatePlaceholder */
+      /* App uploads files and sets status on blocks with ed.updateProgress */
       /* Once upload is complete, app hits ed.setCoverSrc */
     },
     // REQUIRED
     onShareUrl: function ({block, url}) {
       /* Ed made the placeholder with block id */
       /* App shares url with given block id */
-      /* App updates status on placeholder blocks with ed.updatePlaceholder */
+      /* App updates status on placeholder blocks with ed.updateProgress */
       /* On share / measurement finishing, app replaces placeholder blocks with ed.setContent */
     },
     // REQUIRED
@@ -86,12 +86,12 @@ available to use like this:
     // OPTIONAL
     onDropFiles: function (index, files) {
       /* App calls ed.insertPlaceholders(index, files.length) and gets array of ids back */
-      /* App uploads files and sets status on placeholder blocks with ed.updatePlaceholder */
+      /* App uploads files and sets status on placeholder blocks with ed.updateProgress */
       /* On upload / measurement finishing, app replaces placeholder blocks with ed.setContent */
     },
     // OPTIONAL
     onDropFileOnBlock: function (id, file) {
-      /* App uploads files and sets status on block with ed.updatePlaceholder */
+      /* App uploads files and sets status on block with ed.updateProgress */
       /* Once upload is complete, app hits ed.setCoverSrc */
     },
     // OPTIONAL
@@ -117,7 +117,7 @@ available to use like this:
   
   // Update placeholder metadata
   // {status (string), progress (number 0-100), failed (boolean)}
-  ed.updatePlaceholder(id, metadata)
+  ed.updateProgress(id, metadata)
   
   // Once block cover upload completes
   // `cover` is object with {src, width, height}

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -96,7 +96,8 @@ function filesUploadSim (index, files) {
   for (let i = 0, len = files.length; i < len; i++) {
     const file = files[i]
     const url = URL.createObjectURL(file)
-    ed.setCoverPreview(ids[i], url)
+    const id = ids[i]
+    ed.setCoverPreview(id, url)
   }
 
   console.log('app uploads files now and calls `ed.updateProgress(id, meta)` with updates')
@@ -110,6 +111,7 @@ function filesUploadSim (index, files) {
     },
     function () {
       const updatedBlocks = ids.map(function (id, index) {
+        ed.updateProgress(id, {progress: null})
         return (
           { id
           , type: 'image'
@@ -306,6 +308,7 @@ function makeRequestCoverUploadInputOnChange (id) {
     const file = input.files[0]
     const src = URL.createObjectURL(file)
     ed.setCoverPreview(id, src)
+    ed.updateProgress(id, {failed: false})
 
     console.log('app uploads files now and calls ed.updateProgress with updates')
 
@@ -315,6 +318,7 @@ function makeRequestCoverUploadInputOnChange (id) {
         ed.updateProgress(id, {status, progress})
       },
       function () {
+        ed.updateProgress(id, {progress: null})
         // Apps should have dimensions from API
         // and should not need to load the image client-side
         const img = new Image()

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -99,13 +99,13 @@ function filesUploadSim (index, files) {
     ed.setCoverPreview(ids[i], url)
   }
 
-  console.log('app uploads files now and calls `ed.updatePlaceholder(id, meta)` with updates')
+  console.log('app uploads files now and calls `ed.updateProgress(id, meta)` with updates')
 
   simulateProgress(
     function (progress) {
       ids.forEach(function (id, index) {
         let status = `Uploading ${names[index]}`
-        ed.updatePlaceholder(id, {status, progress})
+        ed.updateProgress(id, {status, progress})
       })
     },
     function () {
@@ -130,12 +130,12 @@ document.getElementById('upload').onclick = function () {
 // onShareUrl demo
 function onShareUrlDemo (share) {
   const {block, url} = share
-  console.log('onShareUrl: app shares url now and calls ed.updatePlaceholder() with updates', share)
+  console.log('onShareUrl: app shares url now and calls ed.updateProgress() with updates', share)
 
   simulateProgress(
     function (progress) {
       const status = `Sharing ${url}`
-      ed.updatePlaceholder(block, {status, progress})
+      ed.updateProgress(block, {status, progress})
     },
     function () {
       console.log('Share: mount block')
@@ -272,7 +272,7 @@ function initializePlaceholderMetadata (content) {
     if (progress === undefined && status === undefined && failed === undefined) {
       continue
     }
-    ed.updatePlaceholder(block.id, {progress, status, failed})
+    ed.updateProgress(block.id, {progress, status, failed})
   }
 }
 
@@ -307,12 +307,12 @@ function makeRequestCoverUploadInputOnChange (id) {
     const src = URL.createObjectURL(file)
     ed.setCoverPreview(id, src)
 
-    console.log('app uploads files now and calls ed.updatePlaceholder with updates')
+    console.log('app uploads files now and calls ed.updateProgress with updates')
 
     simulateProgress(
       function (progress) {
         let status = 'Uploading...'
-        ed.updatePlaceholder(id, {status, progress})
+        ed.updateProgress(id, {status, progress})
       },
       function () {
         // Apps should have dimensions from API
@@ -339,12 +339,12 @@ function onDropFileOnBlockDemo (id, file) {
   const src = URL.createObjectURL(file)
   ed.setCoverPreview(id, src)
 
-  console.log('app uploads files now and calls ed.updatePlaceholder with updates')
+  console.log('app uploads files now and calls ed.updateProgress with updates')
 
   simulateProgress(
     function (progress) {
       let status = 'Uploading...'
-      ed.updatePlaceholder(id, {status, progress})
+      ed.updateProgress(id, {status, progress})
     },
     function () {
       // Apps should have dimensions from API

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -45,6 +45,9 @@ function setup (options) {
     }
 
   mountApp(container, props)
+
+  // Only for fixture demo
+  initializePlaceholderMetadata(props.initialContent)
 }
 const initialContent = (window.location.hash === '#fixture' ? fixtureContent : [])
 setup({menu, initialContent})
@@ -259,6 +262,19 @@ function loadFixture () {
 }
 document.querySelector('#fixture').onclick = loadFixture
 
+function initializePlaceholderMetadata (content) {
+  for (let i = 0, len = content.length; i < len; i++) {
+    const block = content[i]
+    if (!block || !block.id || !block.metadata) {
+      continue
+    }
+    const {progress, status, failed} = block.metadata
+    if (progress === undefined && status === undefined && failed === undefined) {
+      continue
+    }
+    ed.updatePlaceholder(block.id, {progress, status, failed})
+  }
+}
 
 function onPlaceholderCancelDemo (id) {
   console.log(`App would cancel the share or upload with id: ${id}`)

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -138,8 +138,11 @@ export default class App extends React.Component {
   insertPlaceholders (index, count) {
     return this._store.insertPlaceholders(index, count)
   }
-  updatePlaceholder (id, metadata) {
-    this._store.updatePlaceholder(id, metadata)
+  updatePlaceholder () {
+    throw new Error('updatePlaceholder is deprecated: use updateProgress')
+  }
+  updateProgress (id, metadata) {
+    this._store.updateProgress(id, metadata)
   }
   setCoverPreview (id, src) {
     this._store.setCoverPreview(id, src)

--- a/src/components/attribution-editor.js
+++ b/src/components/attribution-editor.js
@@ -150,9 +150,11 @@ class AttributionEditor extends React.Component {
     )
   }
   renderProgress () {
-    const {block} = this.state
-    if (!block || !block.metadata) return
-    const {progress, failed} = block.metadata
+    const {id} = this.props
+    const {store} = this.context
+    const meta = store.getPlaceholderMetadata(id)
+    if (!meta) return
+    const {progress, failed} = meta
     if (progress == null) return
 
     const theme = (failed === true ? 'error' : 'info')

--- a/src/components/attribution-editor.js
+++ b/src/components/attribution-editor.js
@@ -152,7 +152,7 @@ class AttributionEditor extends React.Component {
   renderProgress () {
     const {id} = this.props
     const {store} = this.context
-    const meta = store.getPlaceholderMetadata(id)
+    const meta = store.getProgressInfo(id)
     if (!meta) return
     const {progress, failed} = meta
     if (progress == null) return

--- a/src/components/attribution-editor.js
+++ b/src/components/attribution-editor.js
@@ -67,6 +67,7 @@ class AttributionEditor extends React.Component {
         }
       , this.renderCover()
       , this.renderUnsalvageable()
+      , this.renderFailed()
       , this.renderProgress()
       , el('div'
         , { className: 'AttributionEditor-metadata'
@@ -133,13 +134,11 @@ class AttributionEditor extends React.Component {
   }
   renderUnsalvageable () {
     const {block} = this.state
-    if (!block || !block.cover || !block.cover.unsalvageable || !this.canChangeCover()) return
+    if (!block || !block.cover || !block.cover.unsalvageable) return
 
-    return el(Message
-    , {theme: 'error'}
-    , 'We were unable to find the image originally saved with this block.'
-    , el(Space, {auto: true})
-    , el(Button
+    let upload = null
+    if (this.canChangeCover()) {
+      upload = el(Button
       , { onClick: this.boundOnUploadRequest
         , rounded: true
         , color: 'error'
@@ -147,6 +146,38 @@ class AttributionEditor extends React.Component {
         }
       , 'Upload New Image'
       )
+    }
+
+    return el(Message
+    , {theme: 'error'}
+    , 'We were unable to find the image originally saved with this block.'
+    , el(Space, {auto: true})
+    , upload
+    )
+  }
+  renderFailed () {
+    const {id} = this.props
+    const {store} = this.context
+    const meta = store.getProgressInfo(id)
+    if (!meta || !meta.failed) return
+
+    let upload = null
+    if (this.canChangeCover()) {
+      upload = el(Button
+      , { onClick: this.boundOnUploadRequest
+        , rounded: true
+        , color: 'error'
+        , backgroundColor: 'white'
+        }
+      , 'Upload Image'
+      )
+    }
+
+    return el(Message
+    , {theme: 'error'}
+    , 'Upload failed, please try again'
+    , el(Space, {auto: true})
+    , upload
     )
   }
   renderProgress () {

--- a/src/components/media.js
+++ b/src/components/media.js
@@ -1,5 +1,4 @@
 import React, {createElement as el} from 'react'
-import _ from '../util/lodash'
 
 import Placeholder from './placeholder'
 import AttributionEditor from './attribution-editor'
@@ -14,17 +13,20 @@ class Media extends React.Component {
   constructor (props) {
     super(props)
 
-    const initialBlock = _.cloneDeep(props.initialBlock)
+    const {initialBlock} = props
     const {id} = initialBlock
     this.state = {id, initialBlock}
 
     const {store} = props
     this.boundUpdateBlock = this.updateBlock.bind(this)
-    store.on('media.update', this.boundUpdateBlock)
+    this.boundUpdateBlockAll = this.updateBlockAll.bind(this)
+    store.on('media.update.id', this.boundUpdateBlock)
+    store.on('media.update', this.boundUpdateBlockAll)
   }
   componentWillUnmount () {
     const {store} = this.props
-    store.off('media.update', this.boundUpdateBlock)
+    store.off('media.update.id', this.boundUpdateBlock)
+    store.off('media.update', this.boundUpdateBlockAll)
   }
   getChildContext () {
     return (
@@ -44,14 +46,15 @@ class Media extends React.Component {
       }
     )
   }
-  updateBlock () {
-    const {store} = this.props
-    const {id, initialBlock} = this.state
-    const block = _.cloneDeep(store.getBlock(id))
-    if (_.isEqual(initialBlock, block)) {
+  updateBlock (updateId) {
+    const {id} = this.state
+    if (id !== updateId) {
       return
     }
-    this.setState({initialBlock: block})
+    this.setState({})
+  }
+  updateBlockAll () {
+    this.setState({})
   }
 }
 Media.contextTypes =

--- a/src/components/placeholder.js
+++ b/src/components/placeholder.js
@@ -8,7 +8,7 @@ import Close from 'rebass/dist/Close'
 export default function Placeholder (props, context) {
   const {store} = context
   const {id} = props.initialBlock
-  const metadata = store.getPlaceholderMetadata(id)
+  const metadata = store.getProgressInfo(id)
   if (!metadata) {
     return el('div', {className: 'Placeholder'})
   }

--- a/src/components/placeholder.js
+++ b/src/components/placeholder.js
@@ -7,7 +7,8 @@ import Close from 'rebass/dist/Close'
 
 export default function Placeholder (props, context) {
   const {store} = context
-  const {metadata, id} = props.initialBlock
+  const {id} = props.initialBlock
+  const metadata = store.getPlaceholderMetadata(id)
   if (!metadata) {
     return el('div', {className: 'Placeholder'})
   }

--- a/src/store/ed-store.js
+++ b/src/store/ed-store.js
@@ -21,7 +21,7 @@ export default class EdStore {
     this._events = {}
     this._content = {}
     this._coverPreviews = {}
-    this._placeholderMetadata = {}
+    this._progressInfo = {}
     this._initializeContent(options.initialContent)
 
     // Events
@@ -360,7 +360,7 @@ export default class EdStore {
     }
     return -1
   }
-  updatePlaceholder (id, metadata) {
+  updateProgress (id, metadata) {
     let block = this.getBlock(id)
     if (!block) {
       throw new Error('Can not find this block')
@@ -368,10 +368,10 @@ export default class EdStore {
     if (block.type !== 'placeholder' && block.type !== 'image' && block.type !== 'article') {
       throw new Error('Block is not a placeholder, image, or article block')
     }
-    if (!this._placeholderMetadata[id]) {
-      this._placeholderMetadata[id] = {}
+    if (!this._progressInfo[id]) {
+      this._progressInfo[id] = {}
     }
-    const meta = this._placeholderMetadata[id]
+    const meta = this._progressInfo[id]
     const {status, progress, failed} = metadata
     if (status !== undefined) meta.status = status
     if (progress !== undefined) meta.progress = progress
@@ -379,8 +379,8 @@ export default class EdStore {
     // Let content widgets know to update
     this.trigger('media.update.id', id)
   }
-  getPlaceholderMetadata (id) {
-    return this._placeholderMetadata[id]
+  getProgressInfo (id) {
+    return this._progressInfo[id]
   }
   _placeholderCancel (id) {
     this._removeMediaBlock(id)

--- a/test/plugins/widget.js
+++ b/test/plugins/widget.js
@@ -8,12 +8,12 @@ describe('PluginWidget', function () {
     [ {type: 'h1', html: '<h1>Title</h1>', metadata: {starred: true}}
     , { id: '0001'
       , type: 'placeholder'
-      , metadata: {status: 'Status', starred: true}
+      , metadata: {starred: true}
       }
     , {type: 'text', html: '<p>Text</p>', metadata: {starred: true}}
     , { id: '0000'
       , type: 'placeholder'
-      , metadata: {status: 'Status', starred: true}
+      , metadata: {starred: true}
       }
     , {type: 'text', html: '<p>Text</p>', metadata: {starred: true}}
     ]
@@ -34,6 +34,8 @@ describe('PluginWidget', function () {
           }
       }
     )
+    ed.updatePlaceholder('0001', {status: 'Status'})
+    ed.updatePlaceholder('0000', {status: 'Status'})
   })
   afterEach(function () {
     unmountApp(mount)
@@ -66,43 +68,12 @@ describe('PluginWidget', function () {
       expect(widget).to.exist
       expect(widget.type).to.equal('placeholder')
       expect(widget.el.firstChild.classList.contains('Placeholder')).to.be.true
+      expect(status).to.exist
       expect(status.textContent).to.equal('Status')
     })
 
-    it('updates placeholder widget status via setContent', function (done) {
-      ed._store.on('media.update', function () {
-        const widget = plugin.widgets['0000']
-        const status = widget.el.querySelector('.Placeholder-status')
-        expect(widget.type).to.equal('placeholder')
-        expect(status.textContent).to.equal('Status changed')
-        done()
-      })
-      ed.setContent([
-        { id: '0000'
-        , type: 'placeholder'
-        , metadata: {status: 'Status changed'}
-        }
-      ])
-    })
-
-    it('updates placeholder widget failed via setContent', function (done) {
-      const widget = plugin.widgets['0000']
-      const el = widget.el.querySelector('.Placeholder')
-      ed._store.on('media.update', function () {
-        expect(el.classList.contains('Placeholder-error')).to.be.true
-        done()
-      })
-      expect(el.classList.contains('Placeholder-error')).to.be.false
-      ed.setContent([
-        { id: '0000'
-        , type: 'placeholder'
-        , metadata: {failed: true}
-        }
-      ])
-    })
-
     it('updates placeholder widget status via updatePlaceholder', function (done) {
-      ed._store.on('media.update', function () {
+      ed._store.on('media.update.id', function () {
         const widget = plugin.widgets['0000']
         const status = widget.el.querySelector('.Placeholder-status')
         expect(widget.type).to.equal('placeholder')
@@ -112,10 +83,22 @@ describe('PluginWidget', function () {
       ed.updatePlaceholder('0000', {status: 'Status changed'})
     })
 
+    it('updates placeholder widget progress via updatePlaceholder', function (done) {
+      const widget = plugin.widgets['0000']
+      const progress = widget.el.querySelector('.Progress')
+      expect(progress).to.not.exist
+      ed._store.on('media.update.id', function () {
+        const progress = widget.el.querySelector('.Progress')
+        expect(progress).to.exist
+        done()
+      })
+      ed.updatePlaceholder('0000', {progress: 50})
+    })
+
     it('updates placeholder widget failed true via updatePlaceholder', function (done) {
       const widget = plugin.widgets['0000']
       const el = widget.el.querySelector('.Placeholder')
-      ed._store.on('media.update', function () {
+      ed._store.on('media.update.id', function () {
         expect(el.classList.contains('Placeholder-error')).to.be.true
         done()
       })

--- a/test/plugins/widget.js
+++ b/test/plugins/widget.js
@@ -34,8 +34,8 @@ describe('PluginWidget', function () {
           }
       }
     )
-    ed.updatePlaceholder('0001', {status: 'Status'})
-    ed.updatePlaceholder('0000', {status: 'Status'})
+    ed.updateProgress('0001', {status: 'Status'})
+    ed.updateProgress('0000', {status: 'Status'})
   })
   afterEach(function () {
     unmountApp(mount)
@@ -72,7 +72,7 @@ describe('PluginWidget', function () {
       expect(status.textContent).to.equal('Status')
     })
 
-    it('updates placeholder widget status via updatePlaceholder', function (done) {
+    it('updates placeholder widget status via updateProgress', function (done) {
       ed._store.on('media.update.id', function () {
         const widget = plugin.widgets['0000']
         const status = widget.el.querySelector('.Placeholder-status')
@@ -80,10 +80,10 @@ describe('PluginWidget', function () {
         expect(status.textContent).to.equal('Status changed')
         done()
       })
-      ed.updatePlaceholder('0000', {status: 'Status changed'})
+      ed.updateProgress('0000', {status: 'Status changed'})
     })
 
-    it('updates placeholder widget progress via updatePlaceholder', function (done) {
+    it('updates placeholder widget progress via updateProgress', function (done) {
       const widget = plugin.widgets['0000']
       const progress = widget.el.querySelector('.Progress')
       expect(progress).to.not.exist
@@ -92,10 +92,10 @@ describe('PluginWidget', function () {
         expect(progress).to.exist
         done()
       })
-      ed.updatePlaceholder('0000', {progress: 50})
+      ed.updateProgress('0000', {progress: 50})
     })
 
-    it('updates placeholder widget failed true via updatePlaceholder', function (done) {
+    it('updates placeholder widget failed true via updateProgress', function (done) {
       const widget = plugin.widgets['0000']
       const el = widget.el.querySelector('.Placeholder')
       ed._store.on('media.update.id', function () {
@@ -103,7 +103,7 @@ describe('PluginWidget', function () {
         done()
       })
       expect(el.classList.contains('Placeholder-error')).to.be.false
-      ed.updatePlaceholder('0000', {failed: true})
+      ed.updateProgress('0000', {failed: true})
     })
 
     it('changes widget type via setContent', function (done) {


### PR DESCRIPTION
- BREAKING -- `updatePlaceholder` is now `updateProgress`, with same arguments
- BREAKING -- `{status, progress, failed}` will not be set from initial content or `setContent`: you must call `updateProgress`
- BREAKING -- `ed.updateProgress` updates internally and does not change content block metadata (#237)
- Simplifying updates = perf improvements with `updateProgress`
- `ed.updateProgress(id, {progress: null})` will now remove progress bar
- `ed.updateProgress(id, {failed: true})` will now show an error message and retry button
